### PR TITLE
Add Dockerfile for testing the v1 package

### DIFF
--- a/Dockerfile.test.v1
+++ b/Dockerfile.test.v1
@@ -1,0 +1,21 @@
+FROM fedora:30
+
+RUN dnf install -y java-1.8.0-openjdk-headless maven && \
+    dnf clean all
+
+# Predownload the dependencies, so that execution of the image is fast.
+# Also, this will make us better use Docker build cache, as pom.xml won't
+# be changed very often and so maven dependency installation will be cached.
+# Unfortunately there seems to be no way to download all scope:test
+# dependencies, but at least this downloads most of them.
+RUN mkdir -p /tmp/mock-pom-structure/v1
+COPY pom.xml /tmp/mock-pom-structure/
+COPY v1/pom.xml /tmp/mock-pom-structure/v1
+RUN mvn --batch-mode -f /tmp/mock-pom-structure/v1/pom.xml dependency:go-offline
+
+ENTRYPOINT ["mvn"]
+CMD ["--batch-mode", "test"]
+
+COPY . /tmp/datadog-api-client-java
+
+WORKDIR /tmp/datadog-api-client-java


### PR DESCRIPTION
Using code from [1], and assuming environment variables `DATADOG_API_KEY` and `DATADOG_APP_KEY` are set, the tests can be invoked like this:

```
apigentools -r /path/to/datadog-api-spec/ test --container-env DATADOG_API_KEY=${DATADOG_API_KEY} DATADOG_APP_KEY=${DATADOG_APP_KEY}
```

Alternatively, this can be run just by building the Dockerfile and running the resulting image while passing in the two above mentioned environment variables.

 [1] https://github.com/DataDog/apigentools/pull/6