### PR TITLE
Remove use of DeleteAWSByIdentifier

### DIFF
--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12</version>
+                <version>2.19</version>
                 <configuration>
                     <systemProperties>
                         <property>
@@ -70,8 +70,6 @@
                         </property>
                     </systemProperties>
                     <argLine>-Xms512m -Xmx1500m</argLine>
-                    <parallel>methods</parallel>
-                    <forkMode>pertest</forkMode>
                 </configuration>
             </plugin>
             <plugin>
@@ -221,7 +219,7 @@
             <artifactId>jsr305</artifactId>
             <version>3.0.2</version>
         </dependency>
-        
+
         <!-- HTTP client: jersey-client -->
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/v1/src/test/java/com/datadog/api/client/v1/api/AwsIntegrationApiTest.java
+++ b/v1/src/test/java/com/datadog/api/client/v1/api/AwsIntegrationApiTest.java
@@ -40,8 +40,8 @@ public class AwsIntegrationApiTest extends V1ApiTest  {
 
     @After
     public void removeAccounts() throws ApiException {
-        for (int i=0; i<accountsToDelete.size(); i++) {
-            api.deleteAWSAccount(accountsToDelete);
+        for (AWSAccount account: accountsToDelete) {
+            api.deleteAWSAccount(account);
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

Also put the surefire plugin configuration in the POM to what it was before forced regeneration

