### PR TITLE
Disable templated servers

### DIFF
--- a/src/test/java/com/datadog/api/v1/client/api/V1ApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/V1ApiTest.java
@@ -57,6 +57,8 @@ public abstract class V1ApiTest {
         // WireMock defaults to listening on localhost port 8080
         // http://wiremock.org/docs/configuration/
         generalApiUnitTestClient.setBasePath("http://localhost:8080");
+        // Disable templated servers
+        generalApiUnitTestClient.setServerIndex(null);
 
         // Configure API key authorization with fake key
         ApiKeyAuth apiKeyAuth = (ApiKeyAuth) generalApiUnitTestClient.getAuthentication("apiKeyAuth");


### PR DESCRIPTION
Make sure that wiremock is using `basePath`.