### PR TITLE
Configure support links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Datadog Support
+    url: https://www.datadoghq.com/support/
+    about: Our friendly, knowledgeable support engineers are here to help.
+  - name: Datadog Security
+    url: https://www.datadoghq.com/security/
+    about: We care about security. If you have any questions, or encounter any issues, please contact us.


### PR DESCRIPTION
Add links for users to create support ticket.

see https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser