### PR TITLE
fix retry in log test

### DIFF
--- a/src/test/java/com/datadog/api/v1/client/api/LogsApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/LogsApiTest.java
@@ -14,11 +14,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.ws.rs.core.GenericType;
-import java.time.OffsetDateTime;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeFalse;
 
 /**
  * API tests for LogsApi
@@ -84,14 +82,12 @@ public class LogsApiTest extends V1ApiTest {
             }
         });
 
-
-
         TestUtils.retry(5, 10, () -> {
             try {
                 LogsListResponse logsResponse;
 
                 // Find first log item
-                LogsListRequest logsRequest = request.limit(1);
+                LogsListRequest logsRequest = request.limit(1).startAt(null);
                 logsResponse = api.listLogs().body(logsRequest).execute();
                 assertEquals(1, logsResponse.getLogs().size());
 


### PR DESCRIPTION

### What does this PR do?

the retry would never work, because we would never get the first log message since the `startAt` was never reset.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
