### PR TITLE
Ignore User-Agent header from recorded cassettes

### DIFF
--- a/src/test/java/com/datadog/api/TestUtils.java
+++ b/src/test/java/com/datadog/api/TestUtils.java
@@ -234,7 +234,8 @@ public class TestUtils {
                             !header.getName().equals("Host") &&
                             !header.getName().equals("x-datadog-trace-id") &&
                             !header.getName().equals("x-datadog-parent-id") &&
-                            !header.getName().equals("x-datadog-sampling-priority")
+                            !header.getName().equals("x-datadog-sampling-priority") &&
+                            !header.getName().equals("User-Agent")
                     )
                         cleanHeaders.add(header);
                 }


### PR DESCRIPTION
### What does this PR do?

Ignores User-Agent header from recorded cassettes.

It contains version of JRE, thus test execution from cassettes breaks when run on a different JRE.

### Additional Notes

<!-- Anything else we should know when reviewing? -->


### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [x] This PR does not rely on API client schema changes.
    - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
