### PR TITLE
Don't error on failure to delete aws account

### DIFF
--- a/src/test/java/com/datadog/api/v1/client/api/AwsLogsIntegrationApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/AwsLogsIntegrationApiTest.java
@@ -84,8 +84,13 @@ public class AwsLogsIntegrationApiTest extends V1ApiTest {
             try {
                 AWSApi.deleteAWSAccount().body(uniqueAWSAccount).execute();
             } catch (ApiException e) {
-                System.out.println(String.format("Error deleting AWS Account: %s", e));
-                return false;
+                if(e.getCode() == 400) {
+                    System.out.println(String.format("Error deleting AWS Account: %s. The test was likely a unit test", e));
+                    return true;
+                } else {
+                    System.out.println(String.format("Error deleting AWS Account: %s", e));
+                    return false;
+                }
             }
             return true;
         });


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **
* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely 
manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. 
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." 
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Don't error on failure to delete a test. Deleting an AWS account that doesn't exist now returns a 400 response from Datadog, previously this returned a 2xx. 

Since the test class' `After` method assumes the uniqueAWSAccount (from the `Before`) was created, it tries to delete this account after each test execution. This no longer returns 2xx for the cleanup of a unit test. 

### Additional Notes

<!-- Anything else we should know when reviewing? -->


### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
