### PR TITLE
ci: faster startup of datadog agent

### DIFF
--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -20,7 +20,9 @@ resources:
   containers:
   - container: datadog-agent
     image: datadog/agent:7-jmx
+    options: --health-cmd="exit 0" --health-interval=1s
     ports:
+    - 8125:8125
     - 8126:8126
     env:
       DD_API_KEY: $(ddAPIKey)


### PR DESCRIPTION
Faster start of datadog agent.

related to https://github.com/DataDog/datadog-api-client-go/pull/293