### PR TITLE
Don't test on corretto JDK

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
      matrix:
        # see DEVELOPMENT.md for information why we're using this specific combination
        # of JDKs to run unit tests on
-       java-version: ["adopt@1.8.0-242", "amazon-corretto@1.11.0-6.10.1", "1.14.0"]
+       java-version: ["adopt@1.8.0-242", "1.14.0"]
    runs-on: ubuntu-18.04
    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')
    steps:


### PR DESCRIPTION
### What does this PR do?

As it turns out, AWS CF doesn't run on corretto - as this was the only reason why we tested on corretto, let's remove it.

### Additional Notes

<!-- Anything else we should know when reviewing? -->


### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
