### PR TITLE
Fix Azure integration test flake

### DIFF
--- a/src/test/java/com/datadog/api/v1/client/api/AzureIntegrationApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/AzureIntegrationApiTest.java
@@ -131,6 +131,7 @@ public class AzureIntegrationApiTest extends V1ApiTest {
             assertEquals(new AzureAccount(), retrievedAccount);
         } catch (ApiException e) {
             assertEquals(400, e.getCode());
+            System.out.printf("Listing Azure accounts returned 400, this is ok when no other accounts exist at this moment");
         }
     }
 

--- a/src/test/java/com/datadog/api/v1/client/api/AzureIntegrationApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/AzureIntegrationApiTest.java
@@ -123,9 +123,15 @@ public class AzureIntegrationApiTest extends V1ApiTest {
 
         // Test account deletion as well
         api.deleteAzureIntegration().body(uniqueAzureAccount).execute();
-        listAccounts = api.listAzureIntegration().execute();
-        retrievedAccount = retrieveAccountInList(listAccounts, uniqueAzureAccount.getTenantName());
-        assertEquals(new AzureAccount(), retrievedAccount);
+        try {
+            // the API returns 400 if there are no accounts at all, but because of potential other tests
+            // running, we can never be sure if there are currently other accounts, so we handle both cases
+            listAccounts = api.listAzureIntegration().execute();
+            retrievedAccount = retrieveAccountInList(listAccounts, uniqueAzureAccount.getTenantName());
+            assertEquals(new AzureAccount(), retrievedAccount);
+        } catch (ApiException e) {
+            assertEquals(400, e.getCode());
+        }
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?

Handles a test flake - when listing azure integration accounts after deleting the one created in this test case, we may see no accounts (which results in 400 response) or some accounts created by other tests (which results in 200 response, but the deleted account obviously can't be found).

### Additional Notes

<!-- Anything else we should know when reviewing? -->


### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
