### PR TITLE
Add endpoint-dependent tags to top-level spans when testing

### DIFF
--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -60,7 +60,9 @@ jobs:
         DD_TEST_CLIENT_APP_KEY: $(datadogAPPKey)
         DD_TRACE_ANALYTICS_ENABLED: "true"
         # see docker-compose.yaml for information why we do this
-        DD_TRACE_METHODS: 'org.junit.rules.TestWatcher$$1[evaluate]'
+        # NOTE: this doesn't have double `$$` like the docker-compose line,
+        # as the escaping is different
+        DD_TRACE_METHODS: 'org.junit.rules.TestWatcher$1[evaluate]'
         RECORD: "none"
     - script: |
         bash <(curl -s https://codecov.io/bash) -F integration -v

--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -59,7 +59,8 @@ jobs:
         DD_TEST_CLIENT_API_KEY: $(datadogAPIKey)
         DD_TEST_CLIENT_APP_KEY: $(datadogAPPKey)
         DD_TRACE_ANALYTICS_ENABLED: "true"
-        DD_TRACE_ANNOTATIONS: org.junit.Test
+        # see docker-compose.yaml for information why we do this
+        DD_TRACE_METHODS: 'org.junit.rules.TestWatcher$$1[evaluate]'
         RECORD: "none"
     - script: |
         bash <(curl -s https://codecov.io/bash) -F integration -v

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -40,6 +40,9 @@ import,io.netty:netty-handler-proxy,Apache-2.0,2014 The Netty Project
 import,io.netty:netty-handler,Apache-2.0,2012 The Netty Project
 import,io.netty:netty-resolver,Apache-2.0,2014 The Netty Project
 import,io.netty:netty-transport,Apache-2.0,2012 The Netty Project
+import,io.opentracing:opentracing-api,Apache-2.0,2016-2020 The OpenTracing Authors
+import,io.opentracing:opentracing-noop,Apache-2.0,2016-2020 The OpenTracing Authors
+import,io.opentracing:opentracing-util,Apache-2.0,2016-2020 The OpenTracing Authors
 import,io.swagger:swagger-annotations,Apache-2.0,2016 SmartBear Software
 import,javax.activation:activation,BSD-3-Clause,2018 Oracle and/or its affiliates
 import,javax.activation:javax.activation-api,BSD-3-Clause,1997-2019 Oracle and/or its affiliates

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,16 @@ services:
       DD_TEST_CLIENT_API_KEY: ${DD_TEST_CLIENT_API_KEY}
       DD_TEST_CLIENT_APP_KEY: ${DD_TEST_CLIENT_APP_KEY}
       DD_TRACE_AGENT_PORT: 8126
-      DD_TRACE_ANNOTATIONS: org.junit.Test
+      # We need to trace the org.junit.rules.TestWatcher$1[evaluate] (note below the $ sign has to be escaped
+      # because of yaml). This is because:
+      # * We need to set additional tags on *root* spans to be able to filter by tested endpoints.
+      # * We want to do it in a @Before method, as otherwise we'd have to do it in every single test method.
+      # * In order for the root span to be accessible in a @Before method, we need to trace a method that
+      #   overarches calling @Before methods as well as the test itself - this is
+      #   'org.junit.rules.TestWatcher$$1[evaluate]' (but may change in different JUnit version).
+      # As an additional benefit, this will also trace errors in @After methods, as these are also called
+      # by the TestWatcher.
+      DD_TRACE_METHODS: 'org.junit.rules.TestWatcher$$1[evaluate]'
     labels:
       com.datadoghq.ad.logs: '[{"source": "docker-compose.yml", "service": "datadog-api-client-java"}]'
     working_dir: /datadog-api-client-java

--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,18 @@
             <version>${dd-java-agent-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-util</artifactId>
+            <version>0.33.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <version>0.33.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -15,7 +15,7 @@ for one_dep in `echo $ALL_DEPS`; do
     set +e
     cat LICENSE-3rdparty.csv | grep "$one_dep" > /dev/null 2>&1
     if [ $? -ne 0 ]; then
-        DEPS_NOT_FOUND="${DEPS_NOT_FOUND}\n${one_dep}<LICENSE>,<COPYRIGHT>"
+        DEPS_NOT_FOUND="${DEPS_NOT_FOUND}\nimport,${one_dep},<LICENSE>,<COPYRIGHT>"
     fi
     set -e
 done

--- a/src/test/java/com/datadog/api/TestUtils.java
+++ b/src/test/java/com/datadog/api/TestUtils.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import datadog.trace.api.DDTags;
 import datadog.trace.api.interceptor.MutableSpan;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
@@ -147,6 +148,7 @@ public class TestUtils {
         // https://docs.datadoghq.com/tracing/guide/metrics_namespace/#errors
         // "version" is really the only one we can use here
         protected static final String TRACING_TAG_ENDPOINT = "version";
+        protected static final String TRACING_SPAN_TYPE = "test";
         @Rule
         public WireMockRule wireMockRule = new WireMockRule(options().port(WIREMOCK_PORT));
         @Rule
@@ -304,8 +306,13 @@ public class TestUtils {
                 MutableSpan localRootSpan = ((MutableSpan) span).getLocalRootSpan();
                 localRootSpan.setTag(TRACING_TAG_ENDPOINT, getTracingEndpoint());
                 // we need to set both resourceName and the `resource.name` tag, which is what's displayed in the UI
+                // similar for spanType + `span.type` (which also has to be set as operationName)
                 localRootSpan.setResourceName(getQualifiedTestcaseName());
-                localRootSpan.setTag("resource.name", getQualifiedTestcaseName());
+                localRootSpan.setOperationName(TRACING_SPAN_TYPE);
+                localRootSpan.setSpanType(TRACING_SPAN_TYPE);
+                localRootSpan.setTag("analytics.event", true);
+                localRootSpan.setTag(DDTags.RESOURCE_NAME, getQualifiedTestcaseName());
+                localRootSpan.setTag(DDTags.SPAN_TYPE, TRACING_SPAN_TYPE);
             }
         }
 

--- a/src/test/java/com/datadog/api/TestUtils.java
+++ b/src/test/java/com/datadog/api/TestUtils.java
@@ -310,7 +310,7 @@ public class TestUtils {
                 localRootSpan.setResourceName(getQualifiedTestcaseName());
                 localRootSpan.setOperationName(TRACING_SPAN_TYPE);
                 localRootSpan.setSpanType(TRACING_SPAN_TYPE);
-                localRootSpan.setTag("analytics.event", true);
+                localRootSpan.setTag(DDTags.ANALYTICS_SAMPLE_RATE, 1.0f);
                 localRootSpan.setTag(DDTags.RESOURCE_NAME, getQualifiedTestcaseName());
                 localRootSpan.setTag(DDTags.SPAN_TYPE, TRACING_SPAN_TYPE);
             }

--- a/src/test/java/com/datadog/api/TestUtils.java
+++ b/src/test/java/com/datadog/api/TestUtils.java
@@ -11,6 +11,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import datadog.trace.api.interceptor.MutableSpan;
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
 import org.apache.commons.io.IOUtils;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.junit.After;
@@ -129,7 +133,7 @@ public class TestUtils {
         }
     }
 
-    public static class APITest {
+    public abstract static class APITest {
         protected static final String TEST_API_KEY_NAME = "DD_TEST_CLIENT_API_KEY";
         protected static final String TEST_APP_KEY_NAME = "DD_TEST_CLIENT_APP_KEY";
 
@@ -139,6 +143,10 @@ public class TestUtils {
         protected static String TEST_API_KEY;
         protected static String TEST_APP_KEY;
         protected static int WIREMOCK_PORT = 8080 + SUREFIRE_FORK;
+        // We need to make the tag be something that is then searchable in monitors
+        // https://docs.datadoghq.com/tracing/guide/metrics_namespace/#errors
+        // "version" is really the only one we can use here
+        protected static final String TRACING_TAG_ENDPOINT = "version";
         @Rule
         public WireMockRule wireMockRule = new WireMockRule(options().port(WIREMOCK_PORT));
         @Rule
@@ -146,6 +154,8 @@ public class TestUtils {
         public static ClientAndServer mockServer;
         protected Clock clock;
         protected OffsetDateTime now;
+
+        public abstract String getTracingEndpoint();
 
         /**
          * Combines all cassettes into a single huge one.
@@ -283,6 +293,19 @@ public class TestUtils {
                     clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
                 }
                 now = OffsetDateTime.ofInstant(Instant.now(clock), ZoneOffset.UTC);
+            }
+        }
+
+        @Before
+        public void setTracingTags() {
+            final Span span = GlobalTracer.get().activeSpan();
+            if (span != null) {
+                // if the agent container is not running, span is null
+                MutableSpan localRootSpan = ((MutableSpan) span).getLocalRootSpan();
+                localRootSpan.setTag(TRACING_TAG_ENDPOINT, getTracingEndpoint());
+                // we need to set both resourceName and the `resource.name` tag, which is what's displayed in the UI
+                localRootSpan.setResourceName(getQualifiedTestcaseName());
+                localRootSpan.setTag("resource.name", getQualifiedTestcaseName());
             }
         }
 

--- a/src/test/java/com/datadog/api/v1/client/api/AuthenticationApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/AuthenticationApiTest.java
@@ -29,6 +29,11 @@ public class AuthenticationApiTest extends V1ApiTest {
     // ObjectMapper instance configure to not fail when encountering unknown properties
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
+    @Override
+    public String getTracingEndpoint() {
+        return "validation";
+    }
+
     @BeforeClass
     public static void initApi() {
         api = new AuthenticationApi(generalApiClient);
@@ -52,5 +57,4 @@ public class AuthenticationApiTest extends V1ApiTest {
             assertNotNull(error.getErrors());
         }
     }
-
 }

--- a/src/test/java/com/datadog/api/v1/client/api/AwsIntegrationApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/AwsIntegrationApiTest.java
@@ -59,6 +59,11 @@ public class AwsIntegrationApiTest extends V1ApiTest {
     private static AWSAccountAndLambdaRequest uniqueAWSAccountLambdaRequest = new AWSAccountAndLambdaRequest();
     private static AWSLogsServicesRequest uniqueAWSLogsServicesRequest = new AWSLogsServicesRequest();
 
+    @Override
+    public String getTracingEndpoint() {
+        return "integration-aws";
+    }
+
     @BeforeClass
     public static void initApi() {
         api = new AwsIntegrationApi(generalApiClient);

--- a/src/test/java/com/datadog/api/v1/client/api/AzureIntegrationApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/AzureIntegrationApiTest.java
@@ -40,6 +40,10 @@ public class AzureIntegrationApiTest extends V1ApiTest {
     private final String fixturePrefix = "v1/client/api/azure_fixtures";
     private final String apiUri = "/api/v1/integration/azure";
 
+    @Override
+    public String getTracingEndpoint() {
+        return "integration-azure";
+    }
 
     @BeforeClass
     public static void initApi() {

--- a/src/test/java/com/datadog/api/v1/client/api/DashboardListsApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/DashboardListsApiTest.java
@@ -35,6 +35,11 @@ public class DashboardListsApiTest extends V1ApiTest {
 
     private ArrayList<Long> dashboardListsToDelete;
 
+    @Override
+    public String getTracingEndpoint() {
+        return "dashboard-lists";
+    }
+
     @Before
     public void resetDashboardListsToDelete() {
         dashboardListsToDelete = new ArrayList<Long>();

--- a/src/test/java/com/datadog/api/v1/client/api/DashboardsApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/DashboardsApiTest.java
@@ -58,6 +58,11 @@ public class DashboardsApiTest extends V1ApiTest{
                  .denominator("default(sum:non_existant_metric{*}.as_count(), 2)")
             );
 
+    @Override
+    public String getTracingEndpoint() {
+        return "dashboards";
+    }
+
     @BeforeClass
     public static void initAPI() {
         api = new DashboardsApi(generalApiClient);

--- a/src/test/java/com/datadog/api/v1/client/api/DowntimesApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/DowntimesApiTest.java
@@ -46,6 +46,11 @@ public class DowntimesApiTest extends V1ApiTest {
     private final List<String> testingDowntimeRecurrenceWeekDays = Arrays.asList("Mon", "Tue");
     private final Integer testingUntilDowntimeRecurrenceOccurrences = 10;
 
+    @Override
+    public String getTracingEndpoint() {
+        return "downtimes";
+    }
+
     @Before
     public void resetTest() {
         deleteDowntimes = new ArrayList<>();

--- a/src/test/java/com/datadog/api/v1/client/api/EventsApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/EventsApiTest.java
@@ -36,6 +36,11 @@ public class EventsApiTest extends V1ApiTest {
     // ObjectMapper instance configure to not fail when encountering unknown properties
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
+    @Override
+    public String getTracingEndpoint() {
+        return "events";
+    }
+
     @BeforeClass
     public static void initApi() {
         api = new EventsApi(generalApiClient);

--- a/src/test/java/com/datadog/api/v1/client/api/GcpIntegrationApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/GcpIntegrationApiTest.java
@@ -40,6 +40,11 @@ public class GcpIntegrationApiTest extends V1ApiTest {
     private final String apiUri = "/api/v1/integration/gcp";
     private final String fixturePrefix = "v1/client/api/gcp_fixtures";
 
+    @Override
+    public String getTracingEndpoint() {
+        return "integration-gcp";
+    }
+
     @BeforeClass
     public static void initAPI() {
         api = new GcpIntegrationApi(generalApiClient);

--- a/src/test/java/com/datadog/api/v1/client/api/HostsApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/HostsApiTest.java
@@ -38,6 +38,11 @@ public class HostsApiTest extends V1ApiTest {
     // ObjectMapper instance configure to not fail when encountering unknown properties
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
+    @Override
+    public String getTracingEndpoint() {
+        return "hosts";
+    }
+
     @BeforeClass
     public static void initAPI() {
         api = new HostsApi(generalApiClient);

--- a/src/test/java/com/datadog/api/v1/client/api/IpRangesApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/IpRangesApiTest.java
@@ -26,6 +26,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 public class IpRangesApiTest extends V1ApiTest {
 
     private static IpRangesApi api;
+    @Override
+    public String getTracingEndpoint() {
+        return "ip-ranges";
+    }
 
     @Test
     public void getIPRangesTest() throws ApiException {

--- a/src/test/java/com/datadog/api/v1/client/api/KeyManagementApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/KeyManagementApiTest.java
@@ -45,6 +45,11 @@ public class KeyManagementApiTest extends V1ApiTest {
     private final String appUri = "/api/v1/application_key";
     private final String fixturePrefix = "v1/client/api/keys_fixtures";
 
+    @Override
+    public String getTracingEndpoint() {
+        return "key-management";
+    }
+
     @Before
     public void resetTest() {
         deleteAppKeys = new ArrayList<>();

--- a/src/test/java/com/datadog/api/v1/client/api/LogsApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/LogsApiTest.java
@@ -35,6 +35,11 @@ public class LogsApiTest extends V1ApiTest {
     // ObjectMapper instance configure to not fail when encountering unknown properties
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
+    @Override
+    public String getTracingEndpoint() {
+        return "logs";
+    }
+
     @BeforeClass
     public static void initAPI() {
         api = new LogsApi(generalApiClient);

--- a/src/test/java/com/datadog/api/v1/client/api/LogsIndexesApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/LogsIndexesApiTest.java
@@ -41,6 +41,10 @@ public class LogsIndexesApiTest extends V1ApiTest {
     private final String apiUri = "/api/v1/logs/config/indexes";
     private final String fixturePrefix = "v1/client/api/logs_indexes_fixtures";
 
+    @Override
+    public String getTracingEndpoint() {
+        return "logs-indexes";
+    }
 
     @BeforeClass
     public static void initApi() {

--- a/src/test/java/com/datadog/api/v1/client/api/LogsPipelinesApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/LogsPipelinesApiTest.java
@@ -38,6 +38,11 @@ public class LogsPipelinesApiTest extends V1ApiTest {
     private final LogsPipelinesApi api = new LogsPipelinesApi(generalApiClient);
     private final LogsPipelinesApi fakeAuthApi = new LogsPipelinesApi(generalFakeAuthApiClient);
 
+    @Override
+    public String getTracingEndpoint() {
+        return "logs-pipelines";
+    }
+
     /**
      * Create a Pipeline
      *

--- a/src/test/java/com/datadog/api/v1/client/api/LogsPipelinesLifecycleTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/LogsPipelinesLifecycleTest.java
@@ -24,6 +24,11 @@ public class LogsPipelinesLifecycleTest extends V1ApiTest {
     private static LogsPipelinesApi api;
     private static List<String> pipelinesToDelete;
 
+    @Override
+    public String getTracingEndpoint() {
+        return "logs-pipelines";
+    }
+
     @Before
     public void init() {
         api = new LogsPipelinesApi(generalApiClient);

--- a/src/test/java/com/datadog/api/v1/client/api/LogsPipelinesOrderTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/LogsPipelinesOrderTest.java
@@ -20,6 +20,11 @@ import static org.junit.Assert.assertEquals;
 public class LogsPipelinesOrderTest extends V1ApiTest {
     private static LogsPipelinesApi api;
 
+    @Override
+    public String getTracingEndpoint() {
+        return "logs-pipelines";
+    }
+
     @BeforeClass
     public static void initApi() {
         api = new LogsPipelinesApi(generalApiClient);

--- a/src/test/java/com/datadog/api/v1/client/api/MetricsApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/MetricsApiTest.java
@@ -40,6 +40,11 @@ public class MetricsApiTest extends V1ApiTest {
     private final String fixturePrefix = "v1/client/api/metrics_fixtures";
     private final String apiUri = "/api/v1/metrics";
 
+    @Override
+    public String getTracingEndpoint() {
+        return "metrics";
+    }
+
     @BeforeClass
     public static void initApi() {
         api = new MetricsApi(generalApiClient);

--- a/src/test/java/com/datadog/api/v1/client/api/MonitorsApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/MonitorsApiTest.java
@@ -50,6 +50,11 @@ public class MonitorsApiTest extends V1ApiTest {
     // ObjectMapper instance configure to not fail when encountering unknown properties
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
+    @Override
+    public String getTracingEndpoint() {
+        return "monitors";
+    }
+
     @Before
     public void resetDeleteMonitors() {
         deleteMonitors = new ArrayList<Long>();

--- a/src/test/java/com/datadog/api/v1/client/api/OrganizationsApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/OrganizationsApiTest.java
@@ -44,6 +44,11 @@ public class OrganizationsApiTest extends V1ApiTest {
     private final String apiUri = "/api/v1/org";
     private final String fixturePrefix = "v1/client/api/org_fixtures";
 
+    @Override
+    public String getTracingEndpoint() {
+        return "organizations";
+    }
+
     /**
      * Create child-organization.
      *

--- a/src/test/java/com/datadog/api/v1/client/api/PagerDutyIntegrationApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/PagerDutyIntegrationApiTest.java
@@ -42,6 +42,11 @@ public class PagerDutyIntegrationApiTest extends V1ApiTest {
     // ObjectMapper instance configure to not fail when encountering unknown properties
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
+    @Override
+    public String getTracingEndpoint() {
+        return "integration-pagerduty";
+    }
+
     @BeforeClass
     public static void initAPI() {
         api = new PagerDutyIntegrationApi(generalApiClient);

--- a/src/test/java/com/datadog/api/v1/client/api/ServiceLevelObjectivesApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/ServiceLevelObjectivesApiTest.java
@@ -62,6 +62,11 @@ public class ServiceLevelObjectivesApiTest extends V1ApiTest {
     // ObjectMapper instance configure to not fail when encountering unknown properties
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
+    @Override
+    public String getTracingEndpoint() {
+        return "service-level-objectives";
+    }
+
     @Before
     public void resetDeleteSLOsMonitors() {
         deleteSLOs = new ArrayList<String>();

--- a/src/test/java/com/datadog/api/v1/client/api/SnapshotsApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/SnapshotsApiTest.java
@@ -30,6 +30,11 @@ public class SnapshotsApiTest extends V1ApiTest {
     // ObjectMapper instance configure to not fail when encountering unknown properties
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
+    @Override
+    public String getTracingEndpoint() {
+        return "snapshots";
+    }
+
     @BeforeClass
     public static void initAPI() {
         api = new SnapshotsApi(generalApiClient);

--- a/src/test/java/com/datadog/api/v1/client/api/SyntheticsApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/SyntheticsApiTest.java
@@ -98,6 +98,11 @@ public class SyntheticsApiTest extends V1ApiTest {
             .tags(Arrays.asList("testing:browser"))
             .type(SyntheticsTestDetailsType.BROWSER);
 
+    @Override
+    public String getTracingEndpoint() {
+        return "synthetics";
+    }
+
     @Before
     public void resetDeleteSyntheticsTests() {
         deleteSyntheticsTests = new ArrayList<String>();

--- a/src/test/java/com/datadog/api/v1/client/api/TagsApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/TagsApiTest.java
@@ -37,6 +37,10 @@ public class TagsApiTest extends V1ApiTest {
     // ObjectMapper instance configure to not fail when encountering unknown properties
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
+    @Override
+    public String getTracingEndpoint() {
+        return "tags";
+    }
 
     @BeforeClass
     public static void initAPI() {

--- a/src/test/java/com/datadog/api/v1/client/api/TelemetryTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/TelemetryTest.java
@@ -14,6 +14,11 @@ public class TelemetryTest extends V1ApiTest {
 
     private static AwsIntegrationApi api;
 
+    @Override
+    public String getTracingEndpoint() {
+        return "telemetry";
+    }
+
     @BeforeClass
     public static void initApi() {
         api = new AwsIntegrationApi(generalApiUnitTestClient);

--- a/src/test/java/com/datadog/api/v1/client/api/UsageMeteringApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/UsageMeteringApiTest.java
@@ -48,6 +48,11 @@ public class UsageMeteringApiTest extends V1ApiTest {
     private final String apiUri = "/api/v1/usage";
     private final String fixturePrefix = "v1/client/api/usage_fixtures";
 
+    @Override
+    public String getTracingEndpoint() {
+        return "usage-metering";
+    }
+
     @BeforeClass
     public static void initApi() {
         api = new UsageMeteringApi(generalApiClient);

--- a/src/test/java/com/datadog/api/v1/client/api/UsersApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/UsersApiTest.java
@@ -42,6 +42,11 @@ public class UsersApiTest extends V1ApiTest {
     private final AccessRole testingUserAR = AccessRole.STANDARD;
     private ArrayList<String> disableUsers = null;
 
+    @Override
+    public String getTracingEndpoint() {
+        return "users";
+    }
+
     @Before
     public void resetDisableUsers() {
         disableUsers = new ArrayList<String>();

--- a/src/test/java/com/datadog/api/v2/client/api/DashboardListsApiTest.java
+++ b/src/test/java/com/datadog/api/v2/client/api/DashboardListsApiTest.java
@@ -41,6 +41,11 @@ public class DashboardListsApiTest extends V2APITest {
     private static long dashboardListID;
     private final DashboardListsApi api = new DashboardListsApi(generalApiClient);
 
+    @Override
+    public String getTracingEndpoint() {
+        return "dashboard-lists";
+    }
+
     @After
     public void deleteDashboardList() throws com.datadog.api.v1.client.ApiException {
         dashboardListsApiV1.deleteDashboardList(dashboardListID).execute();

--- a/src/test/java/com/datadog/api/v2/client/api/LogsArchivesApiTest.java
+++ b/src/test/java/com/datadog/api/v2/client/api/LogsArchivesApiTest.java
@@ -56,6 +56,10 @@ public class LogsArchivesApiTest extends V2APITest {
     private final String fixturePrefix = "v2/client/api/logs_archives_fixtures";
     private final String apiUri = "/api/v2/logs/config/archives";
 
+    @Override
+    public String getTracingEndpoint() {
+        return "logs-archives";
+    }
 
     @BeforeClass
     public static void initApi() {

--- a/src/test/java/com/datadog/api/v2/client/api/RolesApiTest.java
+++ b/src/test/java/com/datadog/api/v2/client/api/RolesApiTest.java
@@ -35,6 +35,11 @@ public class RolesApiTest extends V2APITest {
     private final String testingUserName = "Test Datadog Client Java";
     private final String testingUserTitle = "Big boss";
 
+    @Override
+    public String getTracingEndpoint() {
+        return "roles";
+    }
+
     @BeforeClass
     public static void initApi() {
         api = new RolesApi(generalApiClient);

--- a/src/test/java/com/datadog/api/v2/client/api/SecurityMonitoringApiTest.java
+++ b/src/test/java/com/datadog/api/v2/client/api/SecurityMonitoringApiTest.java
@@ -27,6 +27,11 @@ public class SecurityMonitoringApiTest extends V2APITest {
     private SecurityMonitoringApi api;
     private List<SecurityMonitoringRuleResponse> ruleCreateResponses;
 
+    @Override
+    public String getTracingEndpoint() {
+        return "security-monitoring";
+    }
+
     @Before
     public void setUp() throws Exception {
         api = new SecurityMonitoringApi(generalApiClient);

--- a/src/test/java/com/datadog/api/v2/client/api/TelemetryTest.java
+++ b/src/test/java/com/datadog/api/v2/client/api/TelemetryTest.java
@@ -14,6 +14,11 @@ public class TelemetryTest extends V2APITest {
 
     private static DashboardListsApi api;
 
+    @Override
+    public String getTracingEndpoint() {
+        return "telemetry";
+    }
+
     @BeforeClass
     public static void initApi() {
         api = new DashboardListsApi(generalApiUnitTestClient);

--- a/src/test/java/com/datadog/api/v2/client/api/UsersApiTest.java
+++ b/src/test/java/com/datadog/api/v2/client/api/UsersApiTest.java
@@ -33,6 +33,11 @@ public class UsersApiTest extends V2APITest {
     private final String testingUserTitle = "Big boss";
     private ArrayList<String> disableUsers = null;
 
+    @Override
+    public String getTracingEndpoint() {
+        return "users";
+    }
+
     @BeforeClass
     public static void initApi() {
         api = new UsersApi(generalApiClient);


### PR DESCRIPTION

### What does this PR do?

This adds an endpoint-dependent tag to every test span when running tests. Unfortunately the only tag left to use which can be used in monitors is `version`, so that's what I had to utilize.

### Additional Notes

<!-- Anything else we should know when reviewing? -->


### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
