### PR TITLE
Temporarily fix CI Oracle Java install by providing full URL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
      # https://github.com/shyiko/jabba - a tool that can install various JDKs
      # NOTE: when upstream releases version 8, we can change this to:
      # uses: olafurpg/setup-scala@v8
-     uses: bkabrda/setup-scala@0af3a8259815032a2604ba25c4df5ab0b9591e8f
+     uses: bkabrda/setup-scala@2acf8c43d988aa7ce2a2e736892114730d04e1e5
      with:
        java-version: ${{ matrix.java-version }}
        jabba-version: 0.11.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
      matrix:
        # see DEVELOPMENT.md for information why we're using this specific combination
        # of JDKs to run unit tests on
-       java-version: ["adopt@1.8.0-242", "1.14.0=https://download.oracle.com/otn-pub/java/jdk/14.0.2+12/205943a0976c4ed48cb16f1043c5c647/jdk-14.0.2_linux-x64_bin.tar.gz"]
+       java-version: ["adopt@1.8.0-242", "1.14.0=tgz+https://download.oracle.com/otn-pub/java/jdk/14.0.2+12/205943a0976c4ed48cb16f1043c5c647/jdk-14.0.2_linux-x64_bin.tar.gz"]
    runs-on: ubuntu-18.04
    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')
    steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
      matrix:
        # see DEVELOPMENT.md for information why we're using this specific combination
        # of JDKs to run unit tests on
-       java-version: ["adopt@1.8.0-242", "1.14.0"]
+       java-version: ["adopt@1.8.0-242", "1.14.0=https://download.oracle.com/otn-pub/java/jdk/14.0.2+12/205943a0976c4ed48cb16f1043c5c647/jdk-14.0.2_linux-x64_bin.tar.gz"]
    runs-on: ubuntu-18.04
    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')
    steps:


### PR DESCRIPTION

### What does this PR do?

Seems like Oracle removed 14.0.0 version of JDK from their site after releasing 14.0.2. This fixes the problem by providing full URL until it's fixed properly in Jabba.

### Additional Notes

<!-- Anything else we should know when reviewing? -->


### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
