### PR TITLE
Fix Security Monitoring flaky tests

### DIFF
--- a/src/test/java/com/datadog/api/v2/client/api/SecurityMonitoringApiTest.java
+++ b/src/test/java/com/datadog/api/v2/client/api/SecurityMonitoringApiTest.java
@@ -185,7 +185,7 @@ public class SecurityMonitoringApiTest extends V2APITest {
         // Make sure both logs are indexed
         SecurityMonitoringSignalListRequest bothSignalsRequest = new SecurityMonitoringSignalListRequest()
                 .filter(allSignalsFilter);
-        TestUtils.retry(10, 10, () -> {
+        TestUtils.retry(5, 10, () -> {
             try {
                 SecurityMonitoringSignalsListResponse response = api.searchSecurityMonitoringSignals().body(bothSignalsRequest).execute();
                 return response.getData() != null && response.getData().size() == 2;
@@ -195,7 +195,7 @@ public class SecurityMonitoringApiTest extends V2APITest {
         });
 
         // Sort ascending works correctly
-        TestUtils.retry(10, 10, () -> {
+        TestUtils.retry(5, 10, () -> {
             try {
                 SecurityMonitoringSignalsListResponse responseAscending = api.searchSecurityMonitoringSignals()
                         .body(new SecurityMonitoringSignalListRequest()
@@ -203,8 +203,9 @@ public class SecurityMonitoringApiTest extends V2APITest {
                                 .sort(SecurityMonitoringSignalsSort.TIMESTAMP_ASCENDING))
                         .execute();
 
-                if (responseAscending.getData() == null || responseAscending.getData().size() < 2)
+                if (responseAscending.getData() == null || responseAscending.getData().size() < 2) {
                     return false;
+                }
 
                 OffsetDateTime firstTimestamp = responseAscending.getData().get(0).getAttributes().getTimestamp();
                 OffsetDateTime secondTimestamp = responseAscending.getData().get(1).getAttributes().getTimestamp();
@@ -215,7 +216,7 @@ public class SecurityMonitoringApiTest extends V2APITest {
         });
 
         // Sort ascending works correctly
-        TestUtils.retry(10, 10, () -> {
+        TestUtils.retry(5, 10, () -> {
             try {
                 SecurityMonitoringSignalsListResponse responseDescending = api.searchSecurityMonitoringSignals()
                         .body(new SecurityMonitoringSignalListRequest()
@@ -223,8 +224,9 @@ public class SecurityMonitoringApiTest extends V2APITest {
                                 .sort(SecurityMonitoringSignalsSort.TIMESTAMP_DESCENDING))
                         .execute();
 
-                if (responseDescending.getData() == null || responseDescending.getData().size() < 2)
+                if (responseDescending.getData() == null || responseDescending.getData().size() < 2) {
                     return false;
+                }
 
                 OffsetDateTime firstTimestamp = responseDescending.getData().get(0).getAttributes().getTimestamp();
                 OffsetDateTime secondTimestamp = responseDescending.getData().get(1).getAttributes().getTimestamp();
@@ -235,7 +237,7 @@ public class SecurityMonitoringApiTest extends V2APITest {
         });
 
         // Paging
-        TestUtils.retry(10, 10, () -> {
+        TestUtils.retry(5, 10, () -> {
             try {
                 SecurityMonitoringSignalsListResponse pageOneResponse = api.searchSecurityMonitoringSignals()
                         .body(new SecurityMonitoringSignalListRequest()
@@ -243,11 +245,12 @@ public class SecurityMonitoringApiTest extends V2APITest {
                                 .page(new SecurityMonitoringSignalListRequestPage().limit(1)))
                         .execute();
 
-                if (pageOneResponse.getData() == null || pageOneResponse.getData().size() < 1)
+                if (pageOneResponse.getData() == null || pageOneResponse.getData().size() < 1) {
                     return false;
+                }
 
                 String cursor = pageOneResponse.getMeta().getPage().getAfter();
-                boolean correctFirstLink = pageOneResponse.getLinks().getNext().contains(URLEncoder.encode(cursor));
+                boolean firstLinkIsCorrect = pageOneResponse.getLinks().getNext().contains(URLEncoder.encode(cursor));
 
                 SecurityMonitoringSignalsListResponse pageTwoResponse = api.searchSecurityMonitoringSignals()
                         .body(new SecurityMonitoringSignalListRequest()
@@ -256,11 +259,12 @@ public class SecurityMonitoringApiTest extends V2APITest {
                                         .cursor(cursor)
                                         .limit(1)))
                         .execute();
-                if (pageTwoResponse.getData() == null || pageTwoResponse.getData().size() < 1)
+                if (pageTwoResponse.getData() == null || pageTwoResponse.getData().size() < 1) {
                     return false;
-                
-                boolean correctSecondLink = !pageOneResponse.getData().get(0).getId().equals( pageTwoResponse.getData().get(0).getId());
-                return correctFirstLink && correctSecondLink;
+                }
+
+                boolean secondLinkIsDifferent = !pageOneResponse.getData().get(0).getId().equals( pageTwoResponse.getData().get(0).getId());
+                return firstLinkIsCorrect && secondLinkIsDifferent;
             } catch (ApiException ignored) {
                 return false;
             }
@@ -302,8 +306,9 @@ public class SecurityMonitoringApiTest extends V2APITest {
                         .sort(SecurityMonitoringSignalsSort.TIMESTAMP_ASCENDING)
                         .execute();
 
-                if (responseAscending.getData() == null || responseAscending.getData().size() < 2)
+                if (responseAscending.getData() == null || responseAscending.getData().size() < 2) {
                     return false;
+                }
 
                 OffsetDateTime firstTimestamp = responseAscending.getData().get(0).getAttributes().getTimestamp();
                 OffsetDateTime secondTimestamp = responseAscending.getData().get(1).getAttributes().getTimestamp();
@@ -323,8 +328,9 @@ public class SecurityMonitoringApiTest extends V2APITest {
                         .sort(SecurityMonitoringSignalsSort.TIMESTAMP_DESCENDING)
                         .execute();
 
-                if (responseDescending.getData() == null || responseDescending.getData().size() < 2)
+                if (responseDescending.getData() == null || responseDescending.getData().size() < 2) {
                     return false;
+                }
 
                 OffsetDateTime firstTimestamp = responseDescending.getData().get(0).getAttributes().getTimestamp();
                 OffsetDateTime secondTimestamp = responseDescending.getData().get(1).getAttributes().getTimestamp();
@@ -345,11 +351,12 @@ public class SecurityMonitoringApiTest extends V2APITest {
                         .pageLimit(1)
                         .execute();
 
-                if (pageOneResponse.getData() == null || pageOneResponse.getData().size() < 1)
+                if (pageOneResponse.getData() == null || pageOneResponse.getData().size() < 1) {
                     return false;
+                }
 
                 String cursor = pageOneResponse.getMeta().getPage().getAfter();
-                boolean correctFirstLink = pageOneResponse.getLinks().getNext().contains(URLEncoder.encode(cursor));
+                boolean firstLinkIsCorrect  = pageOneResponse.getLinks().getNext().contains(URLEncoder.encode(cursor));
 
                 // Second page
                 SecurityMonitoringSignalsListResponse pageTwoResponse = api.listSecurityMonitoringSignals()
@@ -360,11 +367,12 @@ public class SecurityMonitoringApiTest extends V2APITest {
                         .pageCursor(cursor)
                         .execute();
 
-                if (pageTwoResponse.getData() == null || pageTwoResponse.getData().size() < 1)
+                if (pageTwoResponse.getData() == null || pageTwoResponse.getData().size() < 1) {
                     return false;
+                }
 
-                boolean correctSecondLink = !pageOneResponse.getData().get(0).getId().equals(pageTwoResponse.getData().get(0).getId());
-                return correctFirstLink && correctSecondLink;
+                boolean secondLinkIsDifferent = !pageOneResponse.getData().get(0).getId().equals(pageTwoResponse.getData().get(0).getId());
+                return firstLinkIsCorrect && secondLinkIsDifferent;
             } catch (ApiException ignored) {
                 return false;
             }

--- a/src/test/java/com/datadog/api/v2/client/api/SecurityMonitoringApiTest.java
+++ b/src/test/java/com/datadog/api/v2/client/api/SecurityMonitoringApiTest.java
@@ -173,7 +173,9 @@ public class SecurityMonitoringApiTest extends V2APITest {
         String uniqueName = getUniqueEntityName();
         createRule(uniqueName);
         // Wait for the backend to start processing the rule
-        Thread.sleep(5000);
+        if (TestUtils.getRecordingMode().equals(RecordingMode.MODE_IGNORE)) {
+            Thread.sleep(5000);
+        }
 
         sendLogs(uniqueName);
 
@@ -277,7 +279,9 @@ public class SecurityMonitoringApiTest extends V2APITest {
         String uniqueName = getUniqueEntityName();
         SecurityMonitoringRuleResponse rule = createRule(uniqueName);
         // Wait for the rules to be created
-        Thread.sleep(5000);
+        if (TestUtils.getRecordingMode().equals(RecordingMode.MODE_IGNORE)) {
+            Thread.sleep(5000);
+        }
 
         sendLogs(uniqueName);
 
@@ -401,7 +405,10 @@ public class SecurityMonitoringApiTest extends V2APITest {
         );
 
         // Let's ensure log arrival order
-        Thread.sleep(5000);
+        if (TestUtils.getRecordingMode().equals(RecordingMode.MODE_IGNORE)) {
+            Thread.sleep(5000);
+        }
+
         sendRequest(
                 "POST",
                 intakeURL,

--- a/src/test/java/com/datadog/api/v2/client/api/SecurityMonitoringApiTest.java
+++ b/src/test/java/com/datadog/api/v2/client/api/SecurityMonitoringApiTest.java
@@ -172,7 +172,7 @@ public class SecurityMonitoringApiTest extends V2APITest {
     public void searchSignals() throws Exception {
         String uniqueName = getUniqueEntityName();
         createRule(uniqueName);
-        // Wait for the rules to be created
+        // Wait for the backend to start processing the rule
         Thread.sleep(5000);
 
         sendLogs(uniqueName);


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **
* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely 
manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. 
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

Fix Security Monitoring API integration test flakiness.
These tests were flaky for the following reasons:
- After creating a rule, we need to wait some time before sending logs to that rule.
- We need retries each time we retrieve signals.
- We need to wait some time when sending logs to trigger signals if we want to check the order of the generated signals's timestamps.

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." 
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Additional Notes

Number of retries and waiting times are somewhat arbitrary. Might need some tweaking.


### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
