### PR TITLE
Update keep alive values for Security Monitoring rules

### DIFF
--- a/.apigentools-info
+++ b/.apigentools-info
@@ -4,13 +4,13 @@
     "spec_versions": {
         "v1": {
             "apigentools_version": "1.2.0",
-            "regenerated": "2020-09-03 16:58:20.757702",
-            "spec_repo_commit": "abf6246"
+            "regenerated": "2020-09-10 07:33:42.080172",
+            "spec_repo_commit": "fd35c61"
         },
         "v2": {
             "apigentools_version": "1.2.0",
-            "regenerated": "2020-09-03 16:58:27.410599",
-            "spec_repo_commit": "abf6246"
+            "regenerated": "2020-09-10 07:34:13.702771",
+            "spec_repo_commit": "fd35c61"
         }
     }
 }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4185,6 +4185,8 @@ components:
       - 1800
       - 3600
       - 7200
+      - 10800
+      - 21600
       format: int32
       type: integer
       x-enum-varnames:
@@ -4196,6 +4198,8 @@ components:
       - THIRTY_MINUTES
       - ONE_HOUR
       - TWO_HOURS
+      - THREE_HOURS
+      - SIX_HOURS
     SecurityMonitoringRuleMaxSignalDuration:
       description: |-
         A signal will “close” regardless of the query being matched once the time exceeds the maximum duration.

--- a/api_docs/v2/SecurityMonitoringRuleKeepAlive.md
+++ b/api_docs/v2/SecurityMonitoringRuleKeepAlive.md
@@ -21,5 +21,9 @@
 
 * `TWO_HOURS` (value: `7200`)
 
+* `THREE_HOURS` (value: `10800`)
+
+* `SIX_HOURS` (value: `21600`)
+
 
 

--- a/src/main/java/com/datadog/api/v2/client/model/SecurityMonitoringRuleKeepAlive.java
+++ b/src/main/java/com/datadog/api/v2/client/model/SecurityMonitoringRuleKeepAlive.java
@@ -42,7 +42,11 @@ public enum SecurityMonitoringRuleKeepAlive {
   
   ONE_HOUR(3600),
   
-  TWO_HOURS(7200);
+  TWO_HOURS(7200),
+  
+  THREE_HOURS(10800),
+  
+  SIX_HOURS(21600);
 
   private Integer value;
 

--- a/src/main/java/com/datadog/api/v2/openapi.yaml
+++ b/src/main/java/com/datadog/api/v2/openapi.yaml
@@ -1623,6 +1623,8 @@ components:
       - 1800
       - 3600
       - 7200
+      - 10800
+      - 21600
       format: int32
       type: integer
       x-enum-varnames:
@@ -1634,6 +1636,8 @@ components:
       - THIRTY_MINUTES
       - ONE_HOUR
       - TWO_HOURS
+      - THREE_HOURS
+      - SIX_HOURS
     SecurityMonitoringRuleMaxSignalDuration:
       description: "A signal will \u201Cclose\u201D regardless of the query being\
         \ matched once the time exceeds the maximum duration.\nThis time is calculated\


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **
* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely 
manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. 
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

Update tests for https://github.com/DataDog/datadog-api-spec/pull/547

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." 
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->


### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
