### PR TITLE
Add endpoint to reorder Logs Archives - tests

### DIFF
--- a/src/test/java/com/datadog/api/v2/client/api/LogsArchivesApiTest.java
+++ b/src/test/java/com/datadog/api/v2/client/api/LogsArchivesApiTest.java
@@ -58,8 +58,8 @@ public class LogsArchivesApiTest extends V2APITest {
     private static ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     private final String fixturePrefix = "v2/client/api/logs_archives_fixtures";
-    private final String apiUri = "/api/v2/logs/config/archives";
-    private final String apiUriOrder = "/api/v2/logs/config/archive-order";
+    private final String apiUriForArchives = "/api/v2/logs/config/archives";
+    private final String apiUriForArchiveOrder = "/api/v2/logs/config/archive-order";
 
     @Override
     public String getTracingEndpoint() {
@@ -85,7 +85,7 @@ public class LogsArchivesApiTest extends V2APITest {
         LogsArchiveCreateRequest archive = createLogsArchiveCreateRequestS3();
         String archiveType = "s3";
         String outputData = TestUtils.getFixture(String.format("%s/%s/out/%s", fixturePrefix, archiveType, "create.json"));
-        stubFor(post(urlPathEqualTo(apiUri))
+        stubFor(post(urlPathEqualTo(apiUriForArchives))
                 .withRequestBody(equalToJson(objectMapper.writeValueAsString(archive)))
                 .willReturn(okJson(outputData).withStatus(200))
         );
@@ -107,7 +107,7 @@ public class LogsArchivesApiTest extends V2APITest {
         LogsArchiveCreateRequest archive = createLogsArchiveCreateRequestAzure();
         String archiveType = "azure";
         String outputData = TestUtils.getFixture(String.format("%s/%s/out/%s", fixturePrefix, archiveType, "create.json"));
-        stubFor(post(urlPathEqualTo(apiUri))
+        stubFor(post(urlPathEqualTo(apiUriForArchives))
                 .withRequestBody(equalToJson(objectMapper.writeValueAsString(archive)))
                 .willReturn(okJson(outputData).withStatus(200))
         );
@@ -129,7 +129,7 @@ public class LogsArchivesApiTest extends V2APITest {
         LogsArchiveCreateRequest archive = createLogsArchiveCreateRequestGCS();
         String archiveType = "gcs";
         String outputData = TestUtils.getFixture(String.format("%s/%s/out/%s", fixturePrefix, archiveType, "create.json"));
-        stubFor(post(urlPathEqualTo(apiUri))
+        stubFor(post(urlPathEqualTo(apiUriForArchives))
                 .withRequestBody(equalToJson(objectMapper.writeValueAsString(archive)))
                 .willReturn(okJson(outputData).withStatus(200))
         );
@@ -151,7 +151,7 @@ public class LogsArchivesApiTest extends V2APITest {
     public void deleteLogsArchiveTest() throws IOException, ApiException {
         String archiveType = "s3";
         String fixtureData = TestUtils.getFixture(String.format("%s/%s/out/%s", fixturePrefix, archiveType, "getbyid.json"));
-        stubFor(delete(urlPathEqualTo(String.format("%s/%s", apiUri, ARCHIVE_ID)))
+        stubFor(delete(urlPathEqualTo(String.format("%s/%s", apiUriForArchives, ARCHIVE_ID)))
                 .willReturn(okJson(fixtureData).withStatus(204))
         );
         ApiResponse<Void> response = api.deleteLogsArchive(ARCHIVE_ID).executeWithHttpInfo();
@@ -171,7 +171,7 @@ public class LogsArchivesApiTest extends V2APITest {
     public void getLogsArchiveTest() throws IOException, ApiException {
         String archiveType = "s3";
         String fixtureData = TestUtils.getFixture(String.format("%s/%s/out/%s", fixturePrefix, archiveType, "getbyid.json"));
-        stubFor(get(urlPathEqualTo(String.format("%s/%s", apiUri, ARCHIVE_ID)))
+        stubFor(get(urlPathEqualTo(String.format("%s/%s", apiUriForArchives, ARCHIVE_ID)))
                 .willReturn(okJson(fixtureData).withStatus(200))
         );
         LogsArchive response = api.getLogsArchive(ARCHIVE_ID).execute();
@@ -191,7 +191,7 @@ public class LogsArchivesApiTest extends V2APITest {
     public void listLogsArchivesTest() throws IOException, ApiException {
         String archiveType = "s3";
         String fixtureData = TestUtils.getFixture(String.format("%s/%s/out/%s", fixturePrefix, archiveType, "getall.json"));
-        stubFor(get(urlPathEqualTo(apiUri))
+        stubFor(get(urlPathEqualTo(apiUriForArchives))
                 .willReturn(okJson(fixtureData).withStatus(200))
         );
         LogsArchives response = api.listLogsArchives().execute();
@@ -212,7 +212,7 @@ public class LogsArchivesApiTest extends V2APITest {
         String archiveType = "s3";
         LogsArchiveCreateRequest input = createLogsArchiveCreateRequestS3();
         String outputData = TestUtils.getFixture(String.format("%s/%s/out/%s", fixturePrefix, archiveType, "update.json"));
-        stubFor(put(urlPathEqualTo(String.format("%s/%s", apiUri, ARCHIVE_ID)))
+        stubFor(put(urlPathEqualTo(String.format("%s/%s", apiUriForArchives, ARCHIVE_ID)))
                 .withRequestBody(equalToJson(objectMapper.writeValueAsString(input)))
                 .willReturn(okJson(outputData).withStatus(200))
         );
@@ -242,7 +242,7 @@ public class LogsArchivesApiTest extends V2APITest {
     @Test
     public void getArchiveOrderTest() throws ApiException, IOException {
         String outputData = TestUtils.getFixture(String.format("%s/%s/out/%s", fixturePrefix, "archive_order",  "default.json"));
-        stubFor(get(urlPathEqualTo(String.format("%s", apiUriOrder)))
+        stubFor(get(urlPathEqualTo(String.format("%s", apiUriForArchiveOrder)))
                 .willReturn(okJson(outputData).withStatus(200)));
 
 
@@ -257,7 +257,7 @@ public class LogsArchivesApiTest extends V2APITest {
     public void updateArchiveOrderTest() throws ApiException, IOException {
         LogsArchiveOrder input = createUpdatedLogsArchiveOrder();
         String outputData = TestUtils.getFixture(String.format("%s/%s/out/%s", fixturePrefix, "archive_order",  "updated.json"));
-        stubFor(put(urlPathEqualTo(String.format("%s", apiUriOrder)))
+        stubFor(put(urlPathEqualTo(String.format("%s", apiUriForArchiveOrder)))
                 .withRequestBody(equalToJson(objectMapper.writeValueAsString(input)))
                 .willReturn(okJson(outputData).withStatus(200))
         );

--- a/src/test/resources/com/datadog/api/v2/client/api/logs_archives_fixtures/archive_order/out/default.json
+++ b/src/test/resources/com/datadog/api/v2/client/api/logs_archives_fixtures/archive_order/out/default.json
@@ -1,0 +1,1 @@
+{"data":{"attributes":{"archive_ids":["a2zcMylnM4OCHpYusxIi1g","a2zcMylnM4OCHpYusxIi2g","a2zcMylnM4OCHpYusxIi3g"]},"type":"archive_order"}}

--- a/src/test/resources/com/datadog/api/v2/client/api/logs_archives_fixtures/archive_order/out/updated.json
+++ b/src/test/resources/com/datadog/api/v2/client/api/logs_archives_fixtures/archive_order/out/updated.json
@@ -1,0 +1,1 @@
+{"data":{"attributes":{"archive_ids":["a2zcMylnM4OCHpYusxIi2g","a2zcMylnM4OCHpYusxIi3g","a2zcMylnM4OCHpYusxIi1g"]},"type":"archive_order"}}


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **
* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely 
manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. 
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?
add some tests in a new API endpoint to reorder archives. 
Related to PR 528 in api-spec
<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." 
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->


### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [x] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
