### PR TITLE
Update Dashboard widgets data source (event_query, legacy_event_query)

### DIFF
--- a/src/test/java/com/datadog/api/v1/client/api/DashboardsApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/DashboardsApiTest.java
@@ -484,7 +484,7 @@ public class DashboardsApiTest extends V1ApiTest{
         Widget timeseriesWidgetProcessQuery = new Widget().definition(new WidgetDefinition(timeseriesWidgetDefinitionProcessQuery));
         orderedWidgetList.add(timeseriesWidgetProcessQuery);
 
-        // Timeseries Widget with Log query (APM/Log/Network/Rum share schemas, so only test one)
+        // Timeseries Widget with Log query (APM/Log/Network/Rum/Event share schemas, so only test one)
         TimeseriesWidgetDefinition timeseriesWidgetDefinitionLogQuery = new TimeseriesWidgetDefinition()
                 .addRequestsItem(new TimeseriesWidgetRequest()
                         .logQuery(
@@ -520,10 +520,10 @@ public class DashboardsApiTest extends V1ApiTest{
         Widget timeseriesWidgetLogQuery = new Widget().definition(new WidgetDefinition(timeseriesWidgetDefinitionLogQuery));
         orderedWidgetList.add(timeseriesWidgetLogQuery);
 
-        // Timeseries Widget with Event query
+        // Timeseries Widget with Legacy Event query
         TimeseriesWidgetDefinition timeseriesWidgetDefinitionEventQuery = new TimeseriesWidgetDefinition()
                 .addRequestsItem(new TimeseriesWidgetRequest()
-                        .eventQuery(new EventQueryDefinition()
+                        .legacyEventQuery(new EventQueryDefinition()
                                 .search("Build failure").tagsExecution("build")
                         )
                         .style(new WidgetRequestStyle()


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **
* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely 
manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. 
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." 
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR introduces `legacy_event_query` data source based on Event Query Definition.
`event_query` move from Event Query Definition based on Log Query Definition.

Widgets impacted:
- ChangeWidget
- HostMapWidget
- QueryValueWidget
- ScatterPlotWidget
- TableWidget
- TopListWidget
- HeatMapWidget
- DistributionWidget
- TimeseriesWidget

### Additional Notes

<!-- Anything else we should know when reviewing? -->
This introduce a breaking change in the API definition, but `event_query` data source was not used for those widgets.

### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
