### PR TITLE
Update pom to use proper versioning and remove prefix from SCM tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>datadog-api-client</artifactId>
     <packaging>jar</packaging>
     <name>datadog-api-client</name>
-    <version>1.0.0-beta.10-SNAPSHOT</version>
+    <version>1.0.0-beta10-SNAPSHOT</version>
     <url>https://github.com/DataDog/datadog-api-client-java</url>
     <description>Java client library for Datadog API</description>
     <scm>
@@ -71,6 +71,14 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.0.0-M1</version>
+                <configuration>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **
* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely 
manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. 
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

Updates the pom.xml to fix a few items with regards to our versioning. This makes maven have the `defaults` we expect when performing a release and will prevent us from manually having to override any defaults.

* Remove the `.` after beta to be compatible with Java ComparableVersion - https://maven.apache.org/ref/3.5.2/maven-artifact/apidocs/org/apache/maven/artifact/versioning/ComparableVersion.html
  * This means that running the release:pepare + perform commands will now automatically properly bump the beta version and not the bugfix version

* Add a config for the maven-release-plugin (we're already using) to set the default SCM tag to not include the project prefix:
Docs on that - https://maven.apache.org/maven-release/maven-release-plugin/examples/prepare-release.html

### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
