### PR TITLE
Succeed if PR is draft

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check changelog labels
-        if: false == contains(join(github.event.pull_request.labels.*.name, ','), 'changelog/')
+        if: github.event.pull_request.draft == false && false == contains(join(github.event.pull_request.labels.*.name, ','), 'changelog/')
         run: |-
           echo "::error Add 'changelog/*' label";
           exit 1;

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -3,10 +3,11 @@ on: # yamllint disable-line rule:truthy
   pull_request:
     types:
       - labeled
-      - unlabeled
       - opened
-      - synchronize
+      - unlabeled
+      - ready_for_review
       - reopened
+      - synchronize
 
 jobs:
   changelog:


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **
* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely 
manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. 
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?
Don't fail for missing changelog label if the PR is in Draft Mode, this helps reduce noise of "failing" checks until the PR is ready for a review.

Also added the ready_for_review to the list of triggers. Otherwise the workflow won't re-trigger when the PR is moved from Draft mode to Ready

### Additional Notes

<!-- Anything else we should know when reviewing? -->


### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
