### PR TITLE
Don't fail on delete returning a 400

### DIFF
--- a/src/test/java/com/datadog/api/v1/client/api/SyntheticsApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/SyntheticsApiTest.java
@@ -143,13 +143,13 @@ public class SyntheticsApiTest extends V1ApiTest {
     }
 
     @After
-    public void deleteSLOs() throws ApiException {
+    public void deleteSyntheticsTests() throws ApiException {
         if (deleteSyntheticsTests != null) {
             for (String id : deleteSyntheticsTests) {
                 try {
                     api.deleteTests().body(new SyntheticsDeleteTestsPayload().publicIds(Arrays.asList(id))).execute();
                 } catch (ApiException e) {
-                    if (e.getCode() == 404) {
+                    if (e.getCode() == 404 || e.getCode() == 400) {
                         // doesn't exist => continue
                         continue;
                     } else {


### PR DESCRIPTION
### What does this PR do?

Update the name of the method used in `After` to match the resource name (looks to have been a typo)
If the delete endpoint returns a 400, this is safe to ignore since it means we've already successfully deleted the synthetics test as part of the test suite. We can safely ignore this. 

### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
