### PR TITLE
Pin version of the deploy plugin we want to explicitly skip and add specific releasePerform profile

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ deploy_to_sonatype:
     - set -x
 
     - echo "Building release..."
-    - mvn -DskipTests -Darguments=-DskipTests -DdryRun=true --settings ./settings.xml clean deploy
+    - mvn -DperformRelease=true -DskipTests -Darguments=-DskipTests --settings ./settings.xml clean deploy
 
 
 # This job creates the GPG key

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -22,21 +22,6 @@
         </license>
     </licenses>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>nexus</id>
-            <!-- Use the localhost endpoint for testing -->
-            <!-- <url>http://localhost:8081/repository/maven-snapshots/</url> -->
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>nexus</id>
-            <!-- Use the localhost endpoint for testing -->
-            <!-- <url>http://localhost:8081/repository/maven-releases/</url> -->
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <developers>
         <developer>
             <!-- Additions for tests and small generation changes -->
@@ -51,6 +36,73 @@
             <organizationUrl>http://openapitools.org</organizationUrl>
         </developer>
     </developers>
+
+    <profiles>
+        <!-- Performing a release deployment requires setting of performRelease property -->
+        <profile>
+            <id>deploy-artifacts</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>nexus</id>
+                    <!-- Use the localhost endpoint for testing -->
+                    <!-- <url>http://localhost:8081/repository/maven-snapshots/</url> -->
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                </snapshotRepository>
+                <repository>
+                    <id>nexus</id>
+                    <!-- Use the localhost endpoint for testing -->
+                    <!-- <url>http://localhost:8081/repository/maven-releases/</url> -->
+                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+            </distributionManagement>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.6</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>nexus</serverId>
+                            <!-- Use the localhost endpoint for testing -->
+                            <!-- <nexusUrl>http://localhost:8081/repository/maven-releases/</nexusUrl> -->
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <build>
         <resources>
@@ -237,39 +289,6 @@
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.6</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>nexus</serverId>
-                    <!-- Use the localhost endpoint for testing -->
-                    <!-- <nexusUrl>http://localhost:8081/repository/maven-releases/</nexusUrl> -->
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                        <configuration>
-                            <gpgArguments>
-                                <arg>--pinentry-mode</arg>
-                                <arg>loopback</arg>
-                            </gpgArguments>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
### What does this PR do?

Pin the version of the deploy plugin. Without the pin, we see the following warning:

```
Warning:  
Warning:  Some problems were encountered while building the effective model for com.datadoghq:datadog-api-client:jar:1.0.0-beta10-SNAPSHOT
Warning:  'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ line 92, column 21
Warning:  
Warning:  It is highly recommended to fix these problems because they threaten the stability of your build.
Warning:  
Warning:  For this reason, future Maven versions might no longer support building such malformed projects.
Warning:  
```

This PR also adds a new release profile we can activate when performing a release. This is false by default and ensures that we don't require gpg signatures on local builds

### Additional Notes

We only declare this plugin so we can explicitly skip the built-in deploy phase. This ensures we use the nexus deploy process instead to deploy to sonatype. 

### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
