### PR TITLE
Ensure we're not using proxy mode when replaying with v1 client in v2…

### DIFF
--- a/src/test/java/com/datadog/api/v2/client/api/DashboardListsApiTest.java
+++ b/src/test/java/com/datadog/api/v2/client/api/DashboardListsApiTest.java
@@ -56,10 +56,17 @@ public class DashboardListsApiTest extends V2APITest {
     v1Client.configureApiKeys(secrets);
     v1Client.setDebugging("true".equals(System.getenv("DEBUG")));
     ClientConfig config = (ClientConfig) v1Client.getHttpClient().getConfiguration();
-    if (!TestUtils.getRecordingMode().equals(RecordingMode.MODE_IGNORE)) {
-      config.connectorProvider(
-          new HttpUrlConnectorProvider()
-              .connectionFactory(new TestUtils.MockServerProxyConnectionFactory()));
+    if(!TestUtils.getRecordingMode().equals(RecordingMode.MODE_REPLAYING)) {
+      if (!TestUtils.getRecordingMode().equals(RecordingMode.MODE_IGNORE)) {
+        config.connectorProvider(
+                new HttpUrlConnectorProvider()
+                        .connectionFactory(new TestUtils.MockServerProxyConnectionFactory()));
+      }
+    } else {
+      // Set base path to the mock server for replaying
+      v1Client.setBasePath(
+              "https://" + TestUtils.MOCKSERVER_HOST + ":" + TestUtils.MOCKSERVER_PORT);
+      v1Client.setServerIndex(null);
     }
 
     dashboardListsApiV1 = new com.datadog.api.v1.client.api.DashboardListsApi(v1Client);


### PR DESCRIPTION
… tests

<!--
** Requirements for Contributing to this repository **
* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely 
manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. 
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." 
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Recently we started seeing errors on the DashboardList endpoint in CI, specifically:

```
javax.ws.rs.ProcessingException: java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 502 Bad Gateway"
	at com.datadog.api.v2.client.api.DashboardListsApiTest.createDashboardList(DashboardListsApiTest.java:67)
```

This was only impacting the DashboardList test, which creates its own V1 client to make some setup V1 Dash List calls. After enabling `debug` mode, I noticed the v1 calls were attempting to be proxied to the full site, whereas the other calls were attempting to connect directly to the MOCKSERVER URL/PORT. 

To resolve, I updated the v1 client instantiation in the DashList test class to match what we are doing in the V1ApiTest class setup. 


### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
