### PR TITLE
Use https for the developerConnection over ssh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <description>Java client library for Datadog API</description>
     <scm>
         <connection>scm:git:git://github.com/DataDog/datadog-api-client-java.git</connection>
-        <developerConnection>scm:git:git@github.com:DataDog/datadog-api-client-java.git</developerConnection>
+        <developerConnection>scm:git:https://github.com/DataDog/datadog-api-client-java.git</developerConnection>
         <url>https://github.com/DataDog/datadog-api-client-java</url>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
`connection` is for how `mvn` commands should read content of the repo
`developerConnection` is for how `mvn` commands should write content to the repo
Source: https://maven.apache.org/pom.html#SCM

While we're putting this behind CI, we're using the provided token, which needs to connect through https not ssh. 