### PR TITLE
Fix undo parameters

### DIFF
--- a/src/test/java/com/datadog/api/World.java
+++ b/src/test/java/com/datadog/api/World.java
@@ -403,7 +403,14 @@ public class World {
         }
       }
       // Build request from undo parameters and response data
-      Map<String, Object> undoRequestParams = undoSettings.undo.getRequestParameters(data, undoOperation, getObjectMapper());
+      Map<String, Object> undoRequestParams =
+          undoSettings.undo.getRequestParameters(data, undoOperation, getObjectMapper());
+      for (Class c : undoAPIClass.getClasses()) {
+        if (c.getName().endsWith(undoSettings.undo.operationId + "OptionalParameters")) {
+          undoRequestParams.put("parameters", c.getConstructor().newInstance());
+          break;
+        }
+      }
 
       // Execute request
       try {


### PR DESCRIPTION
Some undo APIs takes the additional optional paramaters, we need to pass
it for undo operations to run properly.