### PR TITLE
Fix Usage unit test intermittent failure

### DIFF
--- a/src/test/java/com/datadog/api/v1/client/api/UsageMeteringApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/UsageMeteringApiTest.java
@@ -329,8 +329,9 @@ public class UsageMeteringApiTest extends V1ApiTest {
 
     stubFor(
         get(urlPathEqualTo("/api/v1/usage/summary"))
-            .withQueryParam("start_month", equalTo(startMonth.toString()))
-            .withQueryParam("end_month", equalTo(endMonth.toString()))
+            .withQueryParam(
+                "start_month", equalTo(generalApiClient.formatOffsetDateTime(startMonth)))
+            .withQueryParam("end_month", equalTo(generalApiClient.formatOffsetDateTime(endMonth)))
             .withQueryParam("include_org_details", equalTo("true"))
             .willReturn(
                 okJson(TestUtils.getFixture("v1/client/api/usage_fixtures/usage_summary.json"))));


### PR DESCRIPTION
Using a different date formatting in the tests made them fail sometimes
because of a trailing 0.