### PR TITLE
Fix failing AWS test in ci

### DIFF
--- a/src/test/java/com/datadog/api/v1/client/api/AwsIntegrationApiTest.java
+++ b/src/test/java/com/datadog/api/v1/client/api/AwsIntegrationApiTest.java
@@ -152,7 +152,8 @@ public class AwsIntegrationApiTest extends V1ApiTest {
   public void assertAccountIn(AWSAccount accountToAssert, List<AWSAccount> accounts) {
     for (AWSAccount account : accounts) {
       if (account.getAccessKeyId() != null) {
-        // Skip current account if it uses settings for GovCloud/China where AccountID does not exist
+        // Skip current account if it uses settings for GovCloud/China where AccountID does not
+        // exist
         continue;
       } else if (account.getAccountId().equals(accountToAssert.getAccountId())) {
         assertEquals(account.getRoleName(), accountToAssert.getRoleName());


### PR DESCRIPTION
This pr fixes the following failing AWS test: https://github.com/DataDog/datadog-api-client-java/runs/3831072516?check_suite_focus=true

This failure happens when we are checking to see if `account_id`'s are the same between the created aws account and those returned by the Get all endpoint. `account_id` does not exit for aws accounts configured via `access_key` and `secret_key` (GovCloud/China accounts), hence NullPointerException is thrown.