### PR TITLE
Parse URI in api to make compatible with old javax version

### DIFF
--- a/.generator/templates/libraries/jersey2/ApiClient.mustache
+++ b/.generator/templates/libraries/jersey2/ApiClient.mustache
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
@@ -1107,7 +1108,15 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     } else {
       targetURL = this.basePath + path;
     }
-    WebTarget target = httpClient.target(targetURL);
+    URI parsedURI;
+    try {
+      parsedURI = new URI(targetURL);
+    } catch (URISyntaxException e) {
+      throw new ApiException(e);
+    }
+
+    WebTarget target = httpClient.target(parsedURI);
+
 
     for (Pair queryParam : queryParams) {
       if (queryParam.getValue() != null) {

--- a/src/main/java/com/datadog/api/v1/client/ApiClient.java
+++ b/src/main/java/com/datadog/api/v1/client/ApiClient.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
@@ -1267,7 +1268,14 @@ public class ApiClient extends JavaTimeFormatter {
     } else {
       targetURL = this.basePath + path;
     }
-    WebTarget target = httpClient.target(targetURL);
+    URI parsedURI;
+    try {
+      parsedURI = new URI(targetURL);
+    } catch (URISyntaxException e) {
+      throw new ApiException(e);
+    }
+
+    WebTarget target = httpClient.target(parsedURI);
 
     for (Pair queryParam : queryParams) {
       if (queryParam.getValue() != null) {

--- a/src/main/java/com/datadog/api/v2/client/ApiClient.java
+++ b/src/main/java/com/datadog/api/v2/client/ApiClient.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
@@ -1196,7 +1197,14 @@ public class ApiClient extends JavaTimeFormatter {
     } else {
       targetURL = this.basePath + path;
     }
-    WebTarget target = httpClient.target(targetURL);
+    URI parsedURI;
+    try {
+      parsedURI = new URI(targetURL);
+    } catch (URISyntaxException e) {
+      throw new ApiException(e);
+    }
+
+    WebTarget target = httpClient.target(parsedURI);
 
     for (Pair queryParam : queryParams) {
       if (queryParam.getValue() != null) {


### PR DESCRIPTION

### What does this PR do?

Fix https://github.com/DataDog/datadog-api-client-java/issues/1204

The PR do a minor change on the instantiation of WebTarget (using URI constructor instead of String constructor) so the java api can run with javax 1 environment


### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist

Please check relevant items below:

- [X ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [ X] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
