### PR TITLE
Fix java 16 tests

### DIFF
--- a/src/test/java/com/datadog/api/World.java
+++ b/src/test/java/com/datadog/api/World.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
 import javax.ws.rs.client.Client;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
+import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 public class World {
@@ -179,6 +180,11 @@ public class World {
         httpClient = new TestClient(getName(), "/features/" + getVersion(), getObjectMapper());
       }
       clientClass.getMethod("setHttpClient", Client.class).invoke(client, httpClient);
+    } else if (TestUtils.getRecordingMode().equals(RecordingMode.MODE_IGNORE)) {
+      ClientConfig config =
+          (ClientConfig)
+              ((Client) clientClass.getMethod("getHttpClient").invoke(client)).getConfiguration();
+      config.connectorProvider(new ApacheConnectorProvider());
     }
   }
 

--- a/src/test/java/com/datadog/api/World.java
+++ b/src/test/java/com/datadog/api/World.java
@@ -20,9 +20,9 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.ws.rs.client.Client;
+import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
-import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 public class World {


### PR DESCRIPTION
The default connector doesn't work with PATCH on Java 16 anymore.
See https://github.com/eclipse-ee4j/jersey/issues/4825.