### PR TITLE
Ease running local formatting

### DIFF
--- a/Dockerfile.format
+++ b/Dockerfile.format
@@ -3,7 +3,7 @@ FROM openjdk:15-alpine
 RUN mkdir -p /app
 WORKDIR /app
 
-ADD https://github.com/google/google-java-format/releases/download/google-java-format-1.9/google-java-format-1.9-all-deps.jar /app/google-java-format.jar
+ADD https://github.com/google/google-java-format/releases/download/v1.15.0/google-java-format-1.15.0-all-deps.jar /app/google-java-format.jar
 
 RUN [ "1d98720a5984de85a822aa32a378eeacd4d17480d31cba6e730caae313466b97  /app/google-java-format.jar" = "$(sha256sum /app/google-java-format.jar)" ]
 

--- a/format.sh
+++ b/format.sh
@@ -3,9 +3,9 @@
 set -e
 
 if [ $# -ne 0 ]; then
-    JAR_FILE="/app/google-java-format.jar"
+    JAR_FILE="google-java-format.jar"
     if [[ -e $JAR_FILE ]]; then
-        find "$@" -name '*.java' | xargs java -jar /app/google-java-format.jar -i
+        find "$@" -name '*.java' | xargs java -jar $JAR_FILE -i
     else
         docker build -t google-java-format -f Dockerfile.format .
         docker run --rm -v ${PWD}:/app/src --workdir /app/src google-java-format --replace --set-exit-if-changed $(find "$@" -name '*.java')


### PR DESCRIPTION
To not use docker let's make the default location for the format jar
easier to set.