### PR TITLE
fix: update broken operation for LogsApi

### DIFF
--- a/src/main/java/com/datadog/api/client/v2/api/LogsApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/LogsApi.java
@@ -164,7 +164,7 @@ public class LogsApi {
     try {
       builder =
           apiClient.createBuilder(
-              "LogsApi.aggregateLogs",
+              "v2.LogsApi.aggregateLogs",
               localVarPath,
               new ArrayList<Pair>(),
               localVarHeaderParams,
@@ -389,7 +389,7 @@ public class LogsApi {
     try {
       builder =
           apiClient.createBuilder(
-              "LogsApi.listLogs",
+              "v2.LogsApi.listLogs",
               localVarPath,
               new ArrayList<Pair>(),
               localVarHeaderParams,
@@ -734,7 +734,7 @@ public class LogsApi {
     try {
       builder =
           apiClient.createBuilder(
-              "LogsApi.listLogsGet",
+              "v2.LogsApi.listLogsGet",
               localVarPath,
               localVarQueryParams,
               localVarHeaderParams,
@@ -969,7 +969,7 @@ public class LogsApi {
     try {
       builder =
           apiClient.createBuilder(
-              "LogsApi.submitLog",
+              "v2.LogsApi.submitLog",
               localVarPath,
               localVarQueryParams,
               localVarHeaderParams,


### PR DESCRIPTION
When sending logs to Datadog asynchronously, LogsApi always throws an ApiException saying that 

`"The resource could not be found.<br /><br />\n\n\n", "code": "404 Not Found", "title": "Not Found"}
`

This issue seems to be because of a wrong operation when creating the builder.

This PR will fix this issue for version 2 of the API but the same thing needs to be done for v1 as well (but it is already depreciated)