### PR TITLE
Support differing operation tag and undo tag

### DIFF
--- a/src/test/java/com/datadog/api/Undo.java
+++ b/src/test/java/com/datadog/api/Undo.java
@@ -25,6 +25,7 @@ public class Undo {
 
     public String type;
     public String operationId;
+    public List<String> tags;
     public List<Parameter> parameters;
 
     public Map<String, Object> getRequestParameters(
@@ -79,6 +80,7 @@ public class Undo {
   }
 
   public String getAPIName() {
+    if (undo.tags != null) return Pattern.compile(" ").matcher(undo.tags.get(0)).replaceAll("");
     return Pattern.compile(" ").matcher(tag).replaceAll("");
   }
 

--- a/src/test/java/com/datadog/api/Undo.java
+++ b/src/test/java/com/datadog/api/Undo.java
@@ -23,9 +23,9 @@ public class Undo {
       public String template;
     }
 
+    public String tag;
     public String type;
     public String operationId;
-    public List<String> tags;
     public List<Parameter> parameters;
 
     public Map<String, Object> getRequestParameters(
@@ -80,7 +80,7 @@ public class Undo {
   }
 
   public String getAPIName() {
-    if (undo.tags != null) return Pattern.compile(" ").matcher(undo.tags.get(0)).replaceAll("");
+    if (undo.tag != null) return Pattern.compile(" ").matcher(undo.tag).replaceAll("");
     return Pattern.compile(" ").matcher(tag).replaceAll("");
   }
 


### PR DESCRIPTION
Adds a check in the tests to support when the operation tag and undo operation tag differ. This came up when trying to move the CreateServiceAccount endpoint from the Users tag to the Service Accounts tag. The tests currently try to use the disable_user operation from ServiceAccountsApi, when it should be looking for it in UsersApi