### PR TITLE
Pin linting jdk image to 20 because 21-jdk breaks google-java-format

### DIFF
--- a/Dockerfile.format
+++ b/Dockerfile.format
@@ -1,10 +1,10 @@
-FROM openjdk:20-jdk
+FROM amazoncorretto:19
 
 RUN mkdir -p /app
 WORKDIR /app
 
-ADD https://github.com/google/google-java-format/releases/download/v1.15.0/google-java-format-1.15.0-all-deps.jar /app/google-java-format.jar
+ADD https://github.com/google/google-java-format/releases/download/v1.16.0/google-java-format-1.16.0-all-deps.jar /app/google-java-format.jar
 
-RUN [ "a356bb0236b29c57a3ab678f17a7b027aad603b0960c183a18f1fe322e4f38ea  /app/google-java-format.jar" = "$(sha256sum /app/google-java-format.jar)" ]
+RUN [ "82819a2c5f7067712e0233661b864c1c034f6657d63b8e718b4a50e39ab028f6  /app/google-java-format.jar" = "$(sha256sum /app/google-java-format.jar)" ]
 
 ENTRYPOINT ["java", "-jar", "/app/google-java-format.jar"]

--- a/Dockerfile.format
+++ b/Dockerfile.format
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk
+FROM openjdk:20-jdk
 
 RUN mkdir -p /app
 WORKDIR /app


### PR DESCRIPTION
Seems like the java lint-examples dockerfile uses openjdk:21-jdk but that tag is actually a shared tag for early access builds, and they released a new 21-jdk build 2 days ago that breaks google-java-format.