### PR TITLE
Unskip logs indexes order test

### DIFF
--- a/src/test/java/com/datadog/api/client/v1/api/LogsIndexesApiTest.java
+++ b/src/test/java/com/datadog/api/client/v1/api/LogsIndexesApiTest.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /** API tests for LogsIndexesApi */

--- a/src/test/java/com/datadog/api/client/v1/api/LogsIndexesApiTest.java
+++ b/src/test/java/com/datadog/api/client/v1/api/LogsIndexesApiTest.java
@@ -234,7 +234,6 @@ public class LogsIndexesApiTest extends V1ApiTest {
   }
 
   @Test
-  @Ignore
   public void logsIndexesUpdateErrorsTest() throws IOException {
     try {
       api.updateLogsIndex("shrugs", new LogsIndexUpdateRequest());


### PR DESCRIPTION
500 was fixed on the backend