### PR TITLE
Fix multipart handling

### DIFF
--- a/.generator/src/generator/templates/ApiClient.j2
+++ b/.generator/src/generator/templates/ApiClient.j2
@@ -22,6 +22,7 @@ import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.filter.EncodingFilter;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.jackson.JacksonFeature;
+import org.glassfish.jersey.media.multipart.Boundary;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.MultiPart;
@@ -1077,7 +1078,9 @@ public class ApiClient {
           multiPart.bodyPart(new FormDataBodyPart(contentDisp, parameterToString(param.getValue())));
         }
       }
-      entity = Entity.entity(multiPart, MediaType.MULTIPART_FORM_DATA_TYPE);
+      MediaType mediaDataType = MediaType.MULTIPART_FORM_DATA_TYPE;
+      mediaDataType = Boundary.addBoundary(mediaDataType);
+      entity = Entity.entity(multiPart, mediaDataType);
     } else if (contentType.startsWith("application/x-www-form-urlencoded")) {
       Form form = new Form();
       for (Entry<String, Object> param: formParams.entrySet()) {

--- a/src/main/java/com/datadog/api/client/ApiClient.java
+++ b/src/main/java/com/datadog/api/client/ApiClient.java
@@ -62,6 +62,7 @@ import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.client.filter.EncodingFilter;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.logging.LoggingFeature;
+import org.glassfish.jersey.media.multipart.Boundary;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.MultiPart;
@@ -1350,7 +1351,9 @@ public class ApiClient {
               new FormDataBodyPart(contentDisp, parameterToString(param.getValue())));
         }
       }
-      entity = Entity.entity(multiPart, MediaType.MULTIPART_FORM_DATA_TYPE);
+      MediaType mediaDataType = MediaType.MULTIPART_FORM_DATA_TYPE;
+      mediaDataType = Boundary.addBoundary(mediaDataType);
+      entity = Entity.entity(multiPart, mediaDataType);
     } else if (contentType.startsWith("application/x-www-form-urlencoded")) {
       Form form = new Form();
       for (Entry<String, Object> param : formParams.entrySet()) {


### PR DESCRIPTION
The MultiPart object writer handles the headers in a way that doesn't work for the ApacheConnector. This sets the boundary header manually so that it's know to the MultiPartWriter and the connector.
