### PR TITLE
[K9VULN-3470] ci: remove deprecated field in `datadog-static-analyzer-github-action`

### DIFF
--- a/.github/workflows/static-analysis.datadog.yml
+++ b/.github/workflows/static-analysis.datadog.yml
@@ -17,5 +17,4 @@ jobs:
         dd_app_key: ${{ secrets.DD_APP_KEY }}
         dd_service: datadog-api-client-java
         dd_site: datadoghq.com
-        dd_env: ci
         cpu_count: 2


### PR DESCRIPTION
### What does this PR do?

This removes a [deprecated field](https://github.com/DataDog/datadog-static-analyzer-github-action#deprecated-inputs) in the [datadog-static-analyzer-github-action](https://github.com/DataDog/datadog-static-analyzer-github-action)

### Additional Notes

### Review checklist

Please check relevant items below:

- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
