### PR TITLE
fix the concurrency group of the integration workflow

### DIFF
--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -27,7 +27,6 @@ on:
 jobs:
   examples:
     runs-on: ubuntu-latest
-    if: (github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')) || github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -58,7 +58,7 @@ on:
         required: false
 
 concurrency:
-  group: integration-${{ github.head_ref }}
+  group: integration-java-${{ inputs.target-branch || github.head_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/reusable-java-test.yml
+++ b/.github/workflows/reusable-java-test.yml
@@ -38,7 +38,6 @@ jobs:
         java-version: ${{ fromJSON(inputs.java-versions) }}
         platform: ${{ fromJSON(inputs.platforms) }}
     runs-on: ${{ matrix.platform }}
-    if: (github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')) || github.event_name == 'schedule'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/reusable-javadoc.yml
+++ b/.github/workflows/reusable-javadoc.yml
@@ -22,7 +22,6 @@ on:
 jobs:
   javadoc:
     runs-on: ubuntu-latest
-    if: (github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')) || github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -22,11 +22,6 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
-    if: >
-      (github.event.pull_request.draft == false &&
-       !contains(github.event.pull_request.labels.*.name, 'ci/skip') &&
-       !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')) ||
-      github.event_name == 'schedule'
     steps:
       - name: Get GitHub App token
         if: inputs.enable-commit-changes && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/reusable-shading.yml
+++ b/.github/workflows/reusable-shading.yml
@@ -22,7 +22,6 @@ on:
 jobs:
   shading:
     runs-on: ubuntu-latest
-    if: (github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')) || github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Context

The concurrency group of the integration workflow is currently the same for all client CI when ran from a PR on the specification repo. This causes all integration test jobs but one to be cancelled. 

To prevent this we change the concurrency group so it's dependent on the branch name and the targeted client.

There was also duplication of conditions to run the workflow which is unnecessary and might cause issues down the line.
