### PR TITLE
[SINT-4729] use dd-octo-sts in reusable-ci workflow

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -29,10 +29,6 @@ on:
         type: string
         default: './check-examples.sh'
     secrets:
-      PIPELINE_GITHUB_APP_ID:
-        required: false
-      PIPELINE_GITHUB_APP_PRIVATE_KEY:
-        required: false
       # Integration test secrets
       DD_API_KEY:
         required: false
@@ -49,25 +45,16 @@ jobs:
     with:
       target-branch: ${{ inputs.target-branch }}
       enable-commit-changes: false  # Don't auto-commit in external CI
-    secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
 
   javadoc:
     uses: ./.github/workflows/reusable-javadoc.yml
     with:
       target-branch: ${{ inputs.target-branch }}
-    secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
 
   shading:
     uses: ./.github/workflows/reusable-shading.yml
     with:
       target-branch: ${{ inputs.target-branch }}
-    secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
 
   test:
     uses: ./.github/workflows/reusable-java-test.yml
@@ -77,8 +64,6 @@ jobs:
       platforms: ${{ inputs.platforms }}
       test-script: ${{ inputs.test-script }}
     secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
 
   examples:
@@ -86,9 +71,6 @@ jobs:
     with:
       target-branch: ${{ inputs.target-branch }}
       examples-script: ${{ inputs.examples-script }}
-    secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
 
   integration:
     uses: ./.github/workflows/reusable-integration-test.yml
@@ -96,8 +78,6 @@ jobs:
       target-branch: ${{ inputs.target-branch }}
       has-integration-label: ${{ contains(github.event.pull_request.labels.*.name, 'ci/integrations') }}
     secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       DD_CLIENT_API_KEY: ${{ secrets.DD_CLIENT_API_KEY }}
       DD_CLIENT_APP_KEY: ${{ secrets.DD_CLIENT_APP_KEY }}


### PR DESCRIPTION
## Summary
- Remove `PIPELINE_GITHUB_APP_ID` and `PIPELINE_GITHUB_APP_PRIVATE_KEY` secrets from `reusable-ci.yml`
- These secrets are no longer needed as the called reusable workflows now use dd-octo-sts for token retrieval
- Part of splitting #3477 into per-file PRs

## Changes
- Remove `PIPELINE_GITHUB_APP_ID` and `PIPELINE_GITHUB_APP_PRIVATE_KEY` from the `secrets` input declarations
- Stop passing these secrets to called reusable workflows (`reusable-pre-commit`, `reusable-javadoc`, `reusable-shading`, `reusable-java-test`, `reusable-examples`, `reusable-integration-test`)