### PR TITLE
[SINT-4729] use dd-octo-sts in reusable-examples workflow

### DIFF
--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -18,11 +18,6 @@ on:
         required: false
         type: string
         default: '16'
-    secrets:
-      PIPELINE_GITHUB_APP_ID:
-        required: false
-      PIPELINE_GITHUB_APP_PRIVATE_KEY:
-        required: false
 
 jobs:
   examples:


### PR DESCRIPTION
## Summary
- Remove `PIPELINE_GITHUB_APP_ID` and `PIPELINE_GITHUB_APP_PRIVATE_KEY` secrets from `reusable-examples.yml`
- These secrets are no longer needed as token retrieval is handled via dd-octo-sts
- Part of splitting #3477 into per-file PRs

## Changes
- Remove `PIPELINE_GITHUB_APP_ID` and `PIPELINE_GITHUB_APP_PRIVATE_KEY` from the `secrets` input declarations