### PR TITLE
[SINT-4729] use dd-octo-sts in reusable-java-test workflow

### DIFF
--- a/.github/workflows/reusable-java-test.yml
+++ b/.github/workflows/reusable-java-test.yml
@@ -24,10 +24,6 @@ on:
         type: string
         default: './run-tests.sh'
     secrets:
-      PIPELINE_GITHUB_APP_ID:
-        required: false
-      PIPELINE_GITHUB_APP_PRIVATE_KEY:
-        required: false
       DD_API_KEY:
         required: false
 


### PR DESCRIPTION
## Summary
- Remove `PIPELINE_GITHUB_APP_ID` and `PIPELINE_GITHUB_APP_PRIVATE_KEY` secrets from `reusable-java-test.yml`
- These secrets are no longer needed as token retrieval is handled via dd-octo-sts
- Part of splitting #3477 into per-file PRs

## Changes
- Remove `PIPELINE_GITHUB_APP_ID` and `PIPELINE_GITHUB_APP_PRIVATE_KEY` from the `secrets` input declarations