### PR TITLE
[SINT-4729] use dd-octo-sts in reusable-javadoc workflow

### DIFF
--- a/.github/workflows/reusable-javadoc.yml
+++ b/.github/workflows/reusable-javadoc.yml
@@ -13,11 +13,6 @@ on:
         required: false
         type: string
         default: '8'
-    secrets:
-      PIPELINE_GITHUB_APP_ID:
-        required: false
-      PIPELINE_GITHUB_APP_PRIVATE_KEY:
-        required: false
 
 jobs:
   javadoc:


### PR DESCRIPTION
## Summary
- Remove `PIPELINE_GITHUB_APP_ID` and `PIPELINE_GITHUB_APP_PRIVATE_KEY` secrets from `reusable-javadoc.yml`
- These secrets are no longer needed as token retrieval is handled via dd-octo-sts
- Part of splitting #3477 into per-file PRs

## Changes
- Remove `PIPELINE_GITHUB_APP_ID` and `PIPELINE_GITHUB_APP_PRIVATE_KEY` from the `secrets` input declarations