### PR TITLE
[SINT-4729] use dd-octo-sts in reusable-pre-commit workflow

### DIFF
--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -13,11 +13,6 @@ on:
         required: false
         type: boolean
         default: true
-    secrets:
-      PIPELINE_GITHUB_APP_ID:
-        required: false
-      PIPELINE_GITHUB_APP_PRIVATE_KEY:
-        required: false
 
 env:
   GIT_AUTHOR_EMAIL: "packages@datadoghq.com"
@@ -26,14 +21,16 @@ env:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for dd-octo-sts OIDC token
     steps:
-      - name: Get GitHub App token
+      - name: Get GitHub token via dd-octo-sts
         id: get_token
         if: inputs.enable-commit-changes
-        uses: actions/create-github-app-token@v1
+        uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80  # v1.0.3
         with:
-          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          scope: DataDog/datadog-api-client-java
+          policy: self.github.pre-commit.pull-requests
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary
- Migrate `reusable-pre-commit.yml` from GitHub App token (`actions/create-github-app-token`) to dd-octo-sts OIDC-based token (`DataDog/dd-octo-sts-action`)
- Add job-level `permissions` with `id-token: write` for OIDC
- Part of splitting #3477 into per-file PRs

## Changes
- Replace `actions/create-github-app-token@v1` with `DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80` (v1.0.3)
- Use `scope: DataDog/datadog-api-client-java` and `policy: self.github.pre-commit.pull-requests`
- Add job-level `permissions` with `id-token: write`
- Remove `PIPELINE_GITHUB_APP_ID` and `PIPELINE_GITHUB_APP_PRIVATE_KEY` from the `secrets` input declarations