### PR TITLE
[SINT-4729] use dd-octo-sts in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,6 @@ jobs:
     uses: ./.github/workflows/reusable-pre-commit.yml
     with:
       enable-commit-changes: true
-    secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
 
   javadoc:
     if: >
@@ -60,8 +57,6 @@ jobs:
       platforms: '["ubuntu-latest"]'
       test-script: './run-tests.sh'
     secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
   
   examples:
@@ -78,20 +73,21 @@ jobs:
   report:
     runs-on: ubuntu-latest
     if: always() && github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/')
+    permissions:
+      id-token: write  # Required for dd-octo-sts OIDC token
     needs:
       - test
       - examples
       - javadoc
       - shading
     steps:
-      - name: Get GitHub App token
+      - name: Get GitHub token via dd-octo-sts
         if: github.event_name == 'pull_request'
         id: get_token
-        uses: actions/create-github-app-token@v1
+        uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80  # v1.0.3
         with:
-          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          repositories: datadog-api-spec
+          scope: DataDog/datadog-api-spec
+          policy: datadog-api-client-java.test.post-status
       - name: Post status check
         uses: DataDog/github-actions/post-status-check@v2
         with:


### PR DESCRIPTION
## Summary
- Migrate `test.yml` report job from GitHub App token (`actions/create-github-app-token`) to dd-octo-sts OIDC-based token (`DataDog/dd-octo-sts-action`)
- Part of splitting #3477 into per-file PRs

