### PR TITLE
[SINT-4729] use dd-octo-sts in reusable workflows and test.yml

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -29,10 +29,6 @@ on:
         type: string
         default: './check-examples.sh'
     secrets:
-      PIPELINE_GITHUB_APP_ID:
-        required: false
-      PIPELINE_GITHUB_APP_PRIVATE_KEY:
-        required: false
       # Integration test secrets
       DD_API_KEY:
         required: false
@@ -49,25 +45,16 @@ jobs:
     with:
       target-branch: ${{ inputs.target-branch }}
       enable-commit-changes: false  # Don't auto-commit in external CI
-    secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
 
   javadoc:
     uses: ./.github/workflows/reusable-javadoc.yml
     with:
       target-branch: ${{ inputs.target-branch }}
-    secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
 
   shading:
     uses: ./.github/workflows/reusable-shading.yml
     with:
       target-branch: ${{ inputs.target-branch }}
-    secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
 
   test:
     uses: ./.github/workflows/reusable-java-test.yml
@@ -77,8 +64,6 @@ jobs:
       platforms: ${{ inputs.platforms }}
       test-script: ${{ inputs.test-script }}
     secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
 
   examples:
@@ -86,9 +71,6 @@ jobs:
     with:
       target-branch: ${{ inputs.target-branch }}
       examples-script: ${{ inputs.examples-script }}
-    secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
 
   integration:
     uses: ./.github/workflows/reusable-integration-test.yml
@@ -96,8 +78,6 @@ jobs:
       target-branch: ${{ inputs.target-branch }}
       has-integration-label: ${{ contains(github.event.pull_request.labels.*.name, 'ci/integrations') }}
     secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       DD_CLIENT_API_KEY: ${{ secrets.DD_CLIENT_API_KEY }}
       DD_CLIENT_APP_KEY: ${{ secrets.DD_CLIENT_APP_KEY }}

--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -18,11 +18,6 @@ on:
         required: false
         type: string
         default: '16'
-    secrets:
-      PIPELINE_GITHUB_APP_ID:
-        required: false
-      PIPELINE_GITHUB_APP_PRIVATE_KEY:
-        required: false
 
 jobs:
   examples:

--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -1,8 +1,5 @@
 name: Reusable Integration Test Workflow
 
-permissions:
-  contents: read
-
 on:
   pull_request:
     types:
@@ -44,10 +41,6 @@ on:
         type: boolean
         default: false
     secrets:
-      PIPELINE_GITHUB_APP_ID:
-        required: false
-      PIPELINE_GITHUB_APP_PRIVATE_KEY:
-        required: false
       DD_API_KEY:
         required: true
       DD_CLIENT_API_KEY:
@@ -63,6 +56,9 @@ concurrency:
 
 jobs:
   test_integration:
+    permissions:
+      contents: read
+      id-token: write  # Required for dd-octo-sts OIDC token
     runs-on: ubuntu-latest
     if: >
       (github.event_name == 'pull_request' &&
@@ -82,14 +78,13 @@ jobs:
           DD_HOSTNAME: "none"
           DD_INSIDE_CI: "true"
     steps:
-      - name: Get GitHub App token
+      - name: Get GitHub token via dd-octo-sts
         if: github.event_name == 'pull_request'
         id: get_token
-        uses: actions/create-github-app-token@v1
+        uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80  # v1.0.3
         with:
-          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          repositories: ${{ inputs.target-repo || 'datadog-api-spec' }}
+          scope: DataDog/${{ inputs.target-repo || 'datadog-api-spec' }}
+          policy: datadog-api-client-java.reusable-integration-test.post-status
       - name: Checkout code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/reusable-java-test.yml
+++ b/.github/workflows/reusable-java-test.yml
@@ -24,10 +24,6 @@ on:
         type: string
         default: './run-tests.sh'
     secrets:
-      PIPELINE_GITHUB_APP_ID:
-        required: false
-      PIPELINE_GITHUB_APP_PRIVATE_KEY:
-        required: false
       DD_API_KEY:
         required: false
 

--- a/.github/workflows/reusable-javadoc.yml
+++ b/.github/workflows/reusable-javadoc.yml
@@ -13,11 +13,6 @@ on:
         required: false
         type: string
         default: '8'
-    secrets:
-      PIPELINE_GITHUB_APP_ID:
-        required: false
-      PIPELINE_GITHUB_APP_PRIVATE_KEY:
-        required: false
 
 jobs:
   javadoc:

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -13,11 +13,6 @@ on:
         required: false
         type: boolean
         default: true
-    secrets:
-      PIPELINE_GITHUB_APP_ID:
-        required: false
-      PIPELINE_GITHUB_APP_PRIVATE_KEY:
-        required: false
 
 env:
   GIT_AUTHOR_EMAIL: "packages@datadoghq.com"
@@ -26,14 +21,16 @@ env:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for dd-octo-sts OIDC token
     steps:
-      - name: Get GitHub App token
+      - name: Get GitHub token via dd-octo-sts
         id: get_token
         if: inputs.enable-commit-changes
-        uses: actions/create-github-app-token@v1
+        uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80  # v1.0.3
         with:
-          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          scope: DataDog/datadog-api-client-java
+          policy: self.github.pre-commit.pull-requests
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/reusable-shading.yml
+++ b/.github/workflows/reusable-shading.yml
@@ -13,11 +13,6 @@ on:
         required: false
         type: string
         default: '8'
-    secrets:
-      PIPELINE_GITHUB_APP_ID:
-        required: false
-      PIPELINE_GITHUB_APP_PRIVATE_KEY:
-        required: false
 
 jobs:
   shading:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,6 @@ jobs:
     uses: ./.github/workflows/reusable-pre-commit.yml
     with:
       enable-commit-changes: true
-    secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
 
   javadoc:
     if: >
@@ -60,8 +57,6 @@ jobs:
       platforms: '["ubuntu-latest"]'
       test-script: './run-tests.sh'
     secrets:
-      PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-      PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
   
   examples:
@@ -78,20 +73,21 @@ jobs:
   report:
     runs-on: ubuntu-latest
     if: always() && github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/')
+    permissions:
+      id-token: write  # Required for dd-octo-sts OIDC token
     needs:
       - test
       - examples
       - javadoc
       - shading
     steps:
-      - name: Get GitHub App token
+      - name: Get GitHub token via dd-octo-sts
         if: github.event_name == 'pull_request'
         id: get_token
-        uses: actions/create-github-app-token@v1
+        uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80  # v1.0.3
         with:
-          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          repositories: datadog-api-spec
+          scope: DataDog/datadog-api-spec
+          policy: datadog-api-client-java.test.post-status
       - name: Post status check
         uses: DataDog/github-actions/post-status-check@v2
         with:


### PR DESCRIPTION
Migrate reusable-ci.yml, reusable-examples.yml, reusable-integration-test.yml, reusable-java-test.yml, reusable-javadoc.yml, reusable-pre-commit.yml, reusable-shading.yml, and test.yml from GitHub App token (actions/create-github-app-token) to dd-octo-sts OIDC-based token (DataDog/dd-octo-sts-action)