### PR TITLE
Fix BDD test lookup to handle oneOf wrappers for array indexing

### DIFF
--- a/src/test/java/com/datadog/api/World.java
+++ b/src/test/java/com/datadog/api/World.java
@@ -681,7 +681,17 @@ public class World {
         }
         if (part.contains("]")) {
           int index = Integer.parseInt(part.replaceAll("]", ""));
-          result = List.class.cast(result).get(index);
+          // Unwrap oneOf wrapper before indexing into array
+          try {
+            result = List.class.cast(result).get(index);
+          } catch (ClassCastException e) {
+            try {
+              Object unwrapped = result.getClass().getMethod("getActualInstance").invoke(result);
+              result = List.class.cast(unwrapped).get(index);
+            } catch (Exception ex) {
+              throw e;
+            }
+          }
         } else {
           try {
             result = HashMap.class.cast(result).get(part);


### PR DESCRIPTION
When a oneOf schema wraps an array type, the World.lookup method needs to unwrap the getActualInstance() before casting to List. This fixes ClassCastException when BDD steps navigate paths like group_by[0].facet where group_by is now a oneOf wrapper.

This matches the spec change in datadog-api-spec PR #5141.

<!--
** Requirements for Contributing to this repository **
* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature."
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [ ] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
