### PR TITLE
CRED-2149: Add PAT auth support to Java API client

### DIFF
--- a/.generator/src/generator/templates/ApiClient.j2
+++ b/.generator/src/generator/templates/ApiClient.j2
@@ -223,6 +223,16 @@ public class ApiClient {
     }
     defaultApiClient.configureApiKeys(secrets);
 
+    {%- for name, schema in specs.v2.components.securitySchemes.items() %}
+    {%- if schema.type == "http" and "x-env-name" in schema %}
+    // Configure {{ name }} authorization
+    String {{ name }}Token = System.getenv("{{ schema["x-env-name"] }}");
+    if ({{ name }}Token != null) {
+      defaultApiClient.setBearerToken({{ name }}Token);
+    }
+    {%- endif %}
+    {%- endfor %}
+
     return defaultApiClient;
   }
 
@@ -278,6 +288,15 @@ public class ApiClient {
       authentications.put("{{ name }}", auth);
     } else {
       authentications.put("{{ name }}", new {{ schema.type|upperfirst ~ "Auth" }}("{{ schema["in"] }}", "{{ schema.name }}"));
+    }
+    {%- elif schema.type == "http" %}
+    if (authMap != null) {
+      auth = authMap.get("{{ name }}");
+    }
+    if (auth instanceof HttpBearerAuth) {
+      authentications.put("{{ name }}", auth);
+    } else {
+      authentications.put("{{ name }}", new HttpBearerAuth("{{ schema.scheme }}"));
     }
     {%- endif %}
     {%- endfor %}
@@ -1580,5 +1599,15 @@ public class ApiClient {
       }
       auth.applyToParams(queryParams, headerParams, cookieParams, "", "", uri);
     }
+    {%- for name, schema in specs.v2.components.securitySchemes.items() %}
+    {%- if schema.type == "http" %}
+    // Apply bearer token auth if configured (sent alongside any other auth headers).
+    Authentication {{ name }} = authentications.get("{{ name }}");
+    if ({{ name }} instanceof HttpBearerAuth
+        && ((HttpBearerAuth) {{ name }}).getBearerToken() != null) {
+      {{ name }}.applyToParams(queryParams, headerParams, cookieParams, "", "", uri);
+    }
+    {%- endif %}
+    {%- endfor %}
   }
 }

--- a/src/main/java/com/datadog/api/client/ApiClient.java
+++ b/src/main/java/com/datadog/api/client/ApiClient.java
@@ -1008,6 +1008,11 @@ public class ApiClient {
       secrets.put("appKeyAuth", appKeyAuth);
     }
     defaultApiClient.configureApiKeys(secrets);
+    // Configure bearerAuth authorization
+    String bearerAuthToken = System.getenv("DD_BEARER_TOKEN");
+    if (bearerAuthToken != null) {
+      defaultApiClient.setBearerToken(bearerAuthToken);
+    }
 
     return defaultApiClient;
   }
@@ -1067,6 +1072,14 @@ public class ApiClient {
       authentications.put("appKeyAuth", auth);
     } else {
       authentications.put("appKeyAuth", new ApiKeyAuth("header", "DD-APPLICATION-KEY"));
+    }
+    if (authMap != null) {
+      auth = authMap.get("bearerAuth");
+    }
+    if (auth instanceof HttpBearerAuth) {
+      authentications.put("bearerAuth", auth);
+    } else {
+      authentications.put("bearerAuth", new HttpBearerAuth("bearer"));
     }
     // Prevent the authentications from being modified.
     authentications = Collections.unmodifiableMap(authentications);
@@ -2449,6 +2462,12 @@ public class ApiClient {
         continue;
       }
       auth.applyToParams(queryParams, headerParams, cookieParams, "", "", uri);
+    }
+    // Apply bearer token auth if configured (sent alongside any other auth headers).
+    Authentication bearerAuth = authentications.get("bearerAuth");
+    if (bearerAuth instanceof HttpBearerAuth
+        && ((HttpBearerAuth) bearerAuth).getBearerToken() != null) {
+      bearerAuth.applyToParams(queryParams, headerParams, cookieParams, "", "", uri);
     }
   }
 }

--- a/src/test/java/com/datadog/api/client/auth/HttpBearerAuthTest.java
+++ b/src/test/java/com/datadog/api/client/auth/HttpBearerAuthTest.java
@@ -1,0 +1,82 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+package com.datadog.api.client.auth;
+
+import static org.junit.Assert.*;
+
+import com.datadog.api.client.ApiClient;
+import com.datadog.api.client.ApiException;
+import com.datadog.api.client.Pair;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class HttpBearerAuthTest {
+
+  @Test
+  public void testSetAndGetBearerToken() {
+    HttpBearerAuth auth = new HttpBearerAuth("bearer");
+    assertNull(auth.getBearerToken());
+
+    auth.setBearerToken("test-token-123");
+    assertEquals("test-token-123", auth.getBearerToken());
+  }
+
+  @Test
+  public void testApplyToParamsAddsBearerHeader() throws ApiException {
+    HttpBearerAuth auth = new HttpBearerAuth("bearer");
+    auth.setBearerToken("my-pat-token");
+
+    List<Pair> queryParams = new ArrayList<>();
+    Map<String, String> headerParams = new HashMap<>();
+    Map<String, String> cookieParams = new HashMap<>();
+
+    auth.applyToParams(
+        queryParams, headerParams, cookieParams, "", "", URI.create("https://example.com"));
+
+    assertEquals("Bearer my-pat-token", headerParams.get("Authorization"));
+    assertTrue(queryParams.isEmpty());
+    assertTrue(cookieParams.isEmpty());
+  }
+
+  @Test
+  public void testApplyToParamsNullTokenIsNoOp() throws ApiException {
+    HttpBearerAuth auth = new HttpBearerAuth("bearer");
+
+    List<Pair> queryParams = new ArrayList<>();
+    Map<String, String> headerParams = new HashMap<>();
+    Map<String, String> cookieParams = new HashMap<>();
+
+    auth.applyToParams(
+        queryParams, headerParams, cookieParams, "", "", URI.create("https://example.com"));
+
+    assertFalse(headerParams.containsKey("Authorization"));
+  }
+
+  @Test
+  public void testApiClientRegistersBearerAuth() {
+    ApiClient client = new ApiClient();
+    // setBearerToken should not throw since bearerAuth is now registered
+    client.setBearerToken("test-pat");
+  }
+
+  @Test
+  public void testApiClientSetBearerTokenApplied() throws ApiException {
+    ApiClient client = new ApiClient();
+    client.setBearerToken("my-pat-token");
+
+    // Verify through the authentication map that the token was set
+    Map<String, Authentication> auths = client.getAuthentications();
+    Authentication auth = auths.get("bearerAuth");
+    assertNotNull("bearerAuth should be registered", auth);
+    assertTrue("bearerAuth should be HttpBearerAuth", auth instanceof HttpBearerAuth);
+    assertEquals("my-pat-token", ((HttpBearerAuth) auth).getBearerToken());
+  }
+}


### PR DESCRIPTION
## PR Stack

### API Client Libraries (closed)
All client libraries except Rust already support PATs via the existing OAuth/AuthZ code path. No new changes were needed.

- ~~**Go**: https://github.com/DataDog/datadog-api-client-go/pull/3764 — CRED-2147~~ — PATs work via existing OAuth code path
- ~~**Python**: https://github.com/DataDog/datadog-api-client-python/pull/3243 — CRED-2146~~ — PATs work via existing OAuth code path
- ~~**TypeScript**: https://github.com/DataDog/datadog-api-client-typescript/pull/3588 — CRED-2148~~ — PATs work via existing OAuth code path
- ~~**TypeScript v2**: https://github.com/DataDog/datadog-api-client-typescript/pull/3610 — CRED-2148~~ — PATs work via existing OAuth code path
- ~~**Java**: https://github.com/DataDog/datadog-api-client-java/pull/3555 — CRED-2149~~ — PATs work via existing OAuth code path
- ~~**Ruby**: https://github.com/DataDog/datadog-api-client-ruby/pull/3058 — CRED-2151~~ — PATs work via existing OAuth code path

**Rust**: The Rust client generator does not support OAuth/AuthZ, so PATs cannot be used through the client library today. When OAuth/AuthZ support is added to the Rust generator in the future ([#1438](https://github.com/DataDog/datadog-api-client-rust/pull/1438) has the approach), PATs will work automatically.

### OpenAPI Spec Changes
- https://github.com/DataDog/datadog-api-spec/pull/5164 — CRED-2275: Add PAT/SAT management API endpoints

---

## Closing Note

**This PR is being closed.** PATs can be passed in using the existing OAuth (AuthZ) code path -- no new client library changes are needed. See the test program demonstrating this:
- [TestProgram.java](https://github.com/DataDog/datadog-api-client-java/blob/28da910aafab/src/main/java/com/datadog/api/client/TestProgram.java)