### PR TITLE
fix(formatter): use primitive type instead of schema name in get_response_type (AAWF-1199)

### DIFF
--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -692,11 +692,15 @@ def get_response_type(schema, version):
         else:
             api_response_type = f"List<{simple_type(nested_schema)}>"
     else:
+        primitive = simple_type(response_schema)
         name = schema_name(response_schema)
-        if name:
+        if name and not primitive:
             api_response_type = name
         else:
-            api_response_type = simple_type(response_schema)
+            # Named primitive schemas (e.g. type: string) don't produce a class —
+            # use the primitive type directly and suppress the model import.
+            api_response_type = primitive
+            name = None
 
     if name:
         return api_response_type, f"com.datadog.api.client.{version}.model.{name}"


### PR DESCRIPTION
## Context

When a named component schema has a primitive type (e.g. `type: string`), `get_response_type()` used `schema_name()` directly — emitting the schema name as a class type and generating a model import (`com.datadog.api.client.v2.model.<SchemaName>`). But no class is generated for primitive schemas, causing a compile error in generated examples.

Example: `ConvertCatalogEntityResponse: {type: string}` caused the example to import `com.datadog.api.client.v2.model.ConvertCatalogEntityResponse` which doesn't exist.

## Fix

Check `simple_type()` first — if the schema resolves to a primitive (`String`, `Long`, etc.), use that type directly and suppress the model import. Consistent with how `type_to_java()` already guards against this case.

## Test plan

- [ ] Generated examples for operations with primitive response schemas use the primitive type directly instead of a missing class name