### PR TITLE
Fix consecutive-acronym handling in generated examples

### DIFF
--- a/.generator/conftest.py
+++ b/.generator/conftest.py
@@ -295,9 +295,9 @@ def operation_specs(specs):
 @given(parsers.parse('an instance of "{name}" API'))
 def api(context, api_version, specs, name):
     """Return an API instance."""
-    assert name in {tag["name"].replace(" ", "") for tag in specs[api_version]["tags"]}
+    raw_tag = next(t["name"] for t in specs[api_version]["tags"] if t["name"].replace(" ", "") == name)
     api_name = name.replace("-", "")
-    context["api_instance"] = {"name": api_name}
+    context["api_instance"] = {"name": api_name, "raw_tag": raw_tag}
 
 
 @given(parsers.parse('operation "{name}" enabled'))

--- a/.generator/src/generator/templates/example.j2
+++ b/.generator/src/generator/templates/example.j2
@@ -14,9 +14,9 @@ import {{ package }}.{{ import }};
 
 import com.datadog.api.client.ApiException;
 import com.datadog.api.client.ApiClient;
-import com.datadog.api.client.{{ version }}.api.{{ context.api_instance.name|camel_case|upperfirst }}Api;
+import com.datadog.api.client.{{ version }}.api.{{ context.api_instance.raw_tag|camel_case|upperfirst }}Api;
 {%- if optional_parameters %}
-import com.datadog.api.client.{{ version }}.api.{{ context.api_instance.name|camel_case|upperfirst }}Api.{{ context.api_request.operation_id }}OptionalParameters;
+import com.datadog.api.client.{{ version }}.api.{{ context.api_instance.raw_tag|camel_case|upperfirst }}Api.{{ context.api_request.operation_id }}OptionalParameters;
 {%- endif %}
 {%- if api_reponse_type_import %}
 import {{ api_reponse_type_import}};
@@ -44,7 +44,7 @@ public class Example {
 {%- for operation in context._enable_operations|sort %}
     defaultClient.setUnstableOperationEnabled("{{ version }}.{{ operation|untitle_case }}", true);
 {%- endfor %}
-    {{ context.api_instance.name|camel_case|upperfirst }}Api apiInstance = new {{ context.api_instance.name|camel_case|upperfirst }}Api(defaultClient);
+    {{ context.api_instance.raw_tag|camel_case|upperfirst }}Api apiInstance = new {{ context.api_instance.raw_tag|camel_case|upperfirst }}Api(defaultClient);
 
 {%- for name, values in context._given.items() %}
 
@@ -86,7 +86,7 @@ public class Example {
        System.out.println(item);
       }
     } catch (RuntimeException e) {
-      System.err.println("Exception when calling {{ context.api_instance.name|camel_case|upperfirst }}Api#{{ context.api_request.operation_id|untitle_case }}WithPagination");
+      System.err.println("Exception when calling {{ context.api_instance.raw_tag|camel_case|upperfirst }}Api#{{ context.api_request.operation_id|untitle_case }}WithPagination");
       System.err.println("Reason: " + e.getMessage());
       e.printStackTrace();
     }
@@ -98,7 +98,7 @@ public class Example {
       System.out.println(result);
       {%- endif %}
     } catch (ApiException e) {
-      System.err.println("Exception when calling {{ context.api_instance.name|camel_case|upperfirst }}Api#{{ context.api_request.operation_id|untitle_case }}");
+      System.err.println("Exception when calling {{ context.api_instance.raw_tag|camel_case|upperfirst }}Api#{{ context.api_request.operation_id|untitle_case }}");
       System.err.println("Status code: " + e.getCode());
       System.err.println("Reason: " + e.getResponseBody());
       System.err.println("Response headers: " + e.getResponseHeaders());


### PR DESCRIPTION
## Summary

Fixes broken imports/references in generated examples when an OpenAPI tag contains consecutive acronyms (e.g. `Bits AI SRE`).

The library class (`BitsAiSreApi`) generates correctly because the per-language pipeline goes raw-tag → snake → camel. But the example template re-camel_cased the spaceless form `BitsAISRE` (set in conftest from the BDD `.feature` file) which produced `BitsAisreApi`.

Changes:
- `templates/example.j2`: use `raw_tag|camel_case|upperfirst` instead of `name|camel_case|upperfirst` (5 sites, 6 occurrences).
- `.generator/conftest.py`: stash the raw tag in `context["api_instance"]` so the template can use it.

Behavior is unchanged for any tag without consecutive acronyms.

## Test plan

- [x] Renamed `Bits AI` → `Bits AI SRE` in `.generator/schemas/v2/openapi.yaml` and ran `./generate.sh`.

## Links

- Spec PR (originating change): https://github.com/DataDog/datadog-api-spec/pull/5522
- Sibling: Python — https://github.com/DataDog/datadog-api-client-python/pull/3454
- Sibling: Rust — https://github.com/DataDog/datadog-api-client-rust/pull/1530