### PR TITLE
Allow cursor-based pagination to query extra page until collection is empty

### DIFF
--- a/.generator/src/generator/templates/Api.j2
+++ b/.generator/src/generator/templates/Api.j2
@@ -205,7 +205,7 @@ public class {{ name }} {
   args.put("optionalParams", parameters);
   {%- endif  %}
 
-  PaginationIterable iterator = new PaginationIterable(this, "{{ operationId }}", resultsPath, valueGetterPath, valueSetterPath, valueSetterParamOptional, {% if pagination.pageParam %}false{% else %}true{% endif %}, limit, args, {{ pagination.pageStart | default(0) }});
+  PaginationIterable iterator = new PaginationIterable(this, "{{ operationId }}", resultsPath, valueGetterPath, valueSetterPath, valueSetterParamOptional, {% if pagination.pageParam %}false{% else %}true{% endif %}, {% if pagination.cursorParam %}true{% else %}false{% endif %}, limit, args, {{ pagination.pageStart | default(0) }});
 
   return iterator;
 {%- endmacro %}

--- a/.generator/src/generator/templates/PaginationIterable.j2
+++ b/.generator/src/generator/templates/PaginationIterable.j2
@@ -12,6 +12,7 @@ public class PaginationIterable<T> implements Iterable<T> {
   String[] valueSetterPath;
   Boolean valueSetterParamOptional;
   Boolean offsetPageIncrement;
+  Boolean cursorPagination;
   Object limit;
   LinkedHashMap<String, Object> args;
   int pageStart;
@@ -24,6 +25,7 @@ public class PaginationIterable<T> implements Iterable<T> {
       String valueSetterPath,
       Boolean valueSetterParamOptional,
       Boolean offsetPageIncrement,
+      Boolean cursorPagination,
       Object limit,
       LinkedHashMap<String, Object> args,
       int pageStart) {
@@ -41,6 +43,7 @@ public class PaginationIterable<T> implements Iterable<T> {
     this.valueSetterPath = valueSetterPath.split("\\.");
     this.valueSetterParamOptional = valueSetterParamOptional;
     this.offsetPageIncrement = offsetPageIncrement;
+    this.cursorPagination = cursorPagination;
     this.limit = limit;
     this.args = args;
     this.pageStart = pageStart;

--- a/.generator/src/generator/templates/PaginationIterator.j2
+++ b/.generator/src/generator/templates/PaginationIterator.j2
@@ -142,7 +142,11 @@ public class PaginationIterator<T> implements Iterator<T> {
       return true;
     }
 
-    if (this.data.size() < convertToInt(this.iterable.limit)) {
+    if (this.iterable.cursorPagination) {
+      if (this.data.size() == 0) {
+        return false;
+      }
+    } else if (this.data.size() < convertToInt(this.iterable.limit)) {
       return false;
     }
 

--- a/src/main/java/com/datadog/api/client/PaginationIterable.java
+++ b/src/main/java/com/datadog/api/client/PaginationIterable.java
@@ -16,6 +16,7 @@ public class PaginationIterable<T> implements Iterable<T> {
   String[] valueSetterPath;
   Boolean valueSetterParamOptional;
   Boolean offsetPageIncrement;
+  Boolean cursorPagination;
   Object limit;
   LinkedHashMap<String, Object> args;
   int pageStart;
@@ -28,6 +29,7 @@ public class PaginationIterable<T> implements Iterable<T> {
       String valueSetterPath,
       Boolean valueSetterParamOptional,
       Boolean offsetPageIncrement,
+      Boolean cursorPagination,
       Object limit,
       LinkedHashMap<String, Object> args,
       int pageStart) {
@@ -45,6 +47,7 @@ public class PaginationIterable<T> implements Iterable<T> {
     this.valueSetterPath = valueSetterPath.split("\\.");
     this.valueSetterParamOptional = valueSetterParamOptional;
     this.offsetPageIncrement = offsetPageIncrement;
+    this.cursorPagination = cursorPagination;
     this.limit = limit;
     this.args = args;
     this.pageStart = pageStart;

--- a/src/main/java/com/datadog/api/client/PaginationIterator.java
+++ b/src/main/java/com/datadog/api/client/PaginationIterator.java
@@ -147,7 +147,11 @@ public class PaginationIterator<T> implements Iterator<T> {
       return true;
     }
 
-    if (this.data.size() < convertToInt(this.iterable.limit)) {
+    if (this.iterable.cursorPagination) {
+      if (this.data.size() == 0) {
+        return false;
+      }
+    } else if (this.data.size() < convertToInt(this.iterable.limit)) {
       return false;
     }
 

--- a/src/main/java/com/datadog/api/client/v1/api/DashboardsApi.java
+++ b/src/main/java/com/datadog/api/client/v1/api/DashboardsApi.java
@@ -1543,6 +1543,7 @@ public class DashboardsApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v1/api/MonitorsApi.java
+++ b/src/main/java/com/datadog/api/client/v1/api/MonitorsApi.java
@@ -1329,6 +1329,7 @@ public class MonitorsApi {
             valueSetterPath,
             valueSetterParamOptional,
             false,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v1/api/NotebooksApi.java
+++ b/src/main/java/com/datadog/api/client/v1/api/NotebooksApi.java
@@ -690,6 +690,7 @@ public class NotebooksApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v1/api/ServiceLevelObjectiveCorrectionsApi.java
+++ b/src/main/java/com/datadog/api/client/v1/api/ServiceLevelObjectiveCorrectionsApi.java
@@ -597,6 +597,7 @@ public class ServiceLevelObjectiveCorrectionsApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v1/api/ServiceLevelObjectivesApi.java
+++ b/src/main/java/com/datadog/api/client/v1/api/ServiceLevelObjectivesApi.java
@@ -1445,6 +1445,7 @@ public class ServiceLevelObjectivesApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v1/api/SyntheticsApi.java
+++ b/src/main/java/com/datadog/api/client/v1/api/SyntheticsApi.java
@@ -3654,6 +3654,7 @@ public class SyntheticsApi {
             valueSetterPath,
             valueSetterParamOptional,
             false,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/AuditApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/AuditApi.java
@@ -232,6 +232,7 @@ public class AuditApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);
@@ -485,6 +486,7 @@ public class AuditApi {
             valueGetterPath,
             valueSetterPath,
             valueSetterParamOptional,
+            true,
             true,
             limit,
             args,

--- a/src/main/java/com/datadog/api/client/v2/api/BitsAiApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/BitsAiApi.java
@@ -346,6 +346,7 @@ public class BitsAiApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/CaseManagementApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/CaseManagementApi.java
@@ -3330,6 +3330,7 @@ public class CaseManagementApi {
             valueSetterPath,
             valueSetterParamOptional,
             false,
+            false,
             limit,
             args,
             1);

--- a/src/main/java/com/datadog/api/client/v2/api/CiVisibilityPipelinesApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/CiVisibilityPipelinesApi.java
@@ -520,6 +520,7 @@ public class CiVisibilityPipelinesApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);
@@ -780,6 +781,7 @@ public class CiVisibilityPipelinesApi {
             valueGetterPath,
             valueSetterPath,
             valueSetterParamOptional,
+            true,
             true,
             limit,
             args,

--- a/src/main/java/com/datadog/api/client/v2/api/CiVisibilityTestsApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/CiVisibilityTestsApi.java
@@ -370,6 +370,7 @@ public class CiVisibilityTestsApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);
@@ -627,6 +628,7 @@ public class CiVisibilityTestsApi {
             valueGetterPath,
             valueSetterPath,
             valueSetterParamOptional,
+            true,
             true,
             limit,
             args,

--- a/src/main/java/com/datadog/api/client/v2/api/ContainerImagesApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/ContainerImagesApi.java
@@ -216,6 +216,7 @@ public class ContainerImagesApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/ContainersApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/ContainersApi.java
@@ -216,6 +216,7 @@ public class ContainersApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/DowntimesApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/DowntimesApi.java
@@ -679,6 +679,7 @@ public class DowntimesApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);
@@ -936,6 +937,7 @@ public class DowntimesApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/EventsApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/EventsApi.java
@@ -514,6 +514,7 @@ public class EventsApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);
@@ -767,6 +768,7 @@ public class EventsApi {
             valueGetterPath,
             valueSetterPath,
             valueSetterParamOptional,
+            true,
             true,
             limit,
             args,

--- a/src/main/java/com/datadog/api/client/v2/api/IncidentsApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/IncidentsApi.java
@@ -7630,6 +7630,7 @@ public class IncidentsApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);
@@ -8554,6 +8555,7 @@ public class IncidentsApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/LogsApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/LogsApi.java
@@ -312,6 +312,7 @@ public class LogsApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);
@@ -620,6 +621,7 @@ public class LogsApi {
             valueGetterPath,
             valueSetterPath,
             valueSetterParamOptional,
+            true,
             true,
             limit,
             args,

--- a/src/main/java/com/datadog/api/client/v2/api/MetricsApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/MetricsApi.java
@@ -1855,6 +1855,7 @@ public class MetricsApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/NetworkDeviceMonitoringApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/NetworkDeviceMonitoringApi.java
@@ -535,6 +535,7 @@ public class NetworkDeviceMonitoringApi {
             valueSetterPath,
             valueSetterParamOptional,
             false,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/PowerpackApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/PowerpackApi.java
@@ -581,6 +581,7 @@ public class PowerpackApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/ProcessesApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/ProcessesApi.java
@@ -234,6 +234,7 @@ public class ProcessesApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/RumApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/RumApi.java
@@ -880,6 +880,7 @@ public class RumApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);
@@ -1072,6 +1073,7 @@ public class RumApi {
             valueGetterPath,
             valueSetterPath,
             valueSetterParamOptional,
+            true,
             true,
             limit,
             args,

--- a/src/main/java/com/datadog/api/client/v2/api/ScorecardsApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/ScorecardsApi.java
@@ -1448,6 +1448,7 @@ public class ScorecardsApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);
@@ -1826,6 +1827,7 @@ public class ScorecardsApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/SecurityMonitoringApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/SecurityMonitoringApi.java
@@ -10610,6 +10610,7 @@ public class SecurityMonitoringApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);
@@ -12111,6 +12112,7 @@ public class SecurityMonitoringApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);
@@ -13044,6 +13046,7 @@ public class SecurityMonitoringApi {
             valueGetterPath,
             valueSetterPath,
             valueSetterParamOptional,
+            true,
             true,
             limit,
             args,
@@ -15936,6 +15939,7 @@ public class SecurityMonitoringApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);
@@ -16383,6 +16387,7 @@ public class SecurityMonitoringApi {
             valueGetterPath,
             valueSetterPath,
             valueSetterParamOptional,
+            true,
             true,
             limit,
             args,

--- a/src/main/java/com/datadog/api/client/v2/api/ServiceDefinitionApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/ServiceDefinitionApi.java
@@ -684,6 +684,7 @@ public class ServiceDefinitionApi {
             valueSetterPath,
             valueSetterParamOptional,
             false,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/SoftwareCatalogApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/SoftwareCatalogApi.java
@@ -568,6 +568,7 @@ public class SoftwareCatalogApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);
@@ -872,6 +873,7 @@ public class SoftwareCatalogApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);
@@ -1182,6 +1184,7 @@ public class SoftwareCatalogApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/SpansApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/SpansApi.java
@@ -261,6 +261,7 @@ public class SpansApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);
@@ -555,6 +556,7 @@ public class SpansApi {
             valueGetterPath,
             valueSetterPath,
             valueSetterParamOptional,
+            true,
             true,
             limit,
             args,

--- a/src/main/java/com/datadog/api/client/v2/api/StaticAnalysisApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/StaticAnalysisApi.java
@@ -1743,6 +1743,7 @@ public class StaticAnalysisApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            false,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/TeamsApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/TeamsApi.java
@@ -2598,6 +2598,7 @@ public class TeamsApi {
             valueSetterPath,
             valueSetterParamOptional,
             false,
+            false,
             limit,
             args,
             0);
@@ -3607,6 +3608,7 @@ public class TeamsApi {
             valueSetterPath,
             valueSetterParamOptional,
             false,
+            false,
             limit,
             args,
             0);
@@ -3951,6 +3953,7 @@ public class TeamsApi {
             valueSetterPath,
             valueSetterParamOptional,
             false,
+            false,
             limit,
             args,
             0);
@@ -4238,6 +4241,7 @@ public class TeamsApi {
             valueGetterPath,
             valueSetterPath,
             valueSetterParamOptional,
+            false,
             false,
             limit,
             args,
@@ -4546,6 +4550,7 @@ public class TeamsApi {
             valueGetterPath,
             valueSetterPath,
             valueSetterParamOptional,
+            false,
             false,
             limit,
             args,

--- a/src/main/java/com/datadog/api/client/v2/api/TestOptimizationApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/TestOptimizationApi.java
@@ -619,6 +619,7 @@ public class TestOptimizationApi {
             valueSetterPath,
             valueSetterParamOptional,
             true,
+            true,
             limit,
             args,
             0);

--- a/src/main/java/com/datadog/api/client/v2/api/UsersApi.java
+++ b/src/main/java/com/datadog/api/client/v2/api/UsersApi.java
@@ -1329,6 +1329,7 @@ public class UsersApi {
             valueSetterPath,
             valueSetterParamOptional,
             false,
+            false,
             limit,
             args,
             0);


### PR DESCRIPTION
## Summary

Mirrors [datadog-api-client-go#3769](https://github.com/DataDog/datadog-api-client-go/pull/3769) for the Java client.

Cursor-based paginators now keep querying until the response collection is empty, instead of stopping early when a page returns fewer items than the requested limit. Page-offset and page-number paginations keep their existing behavior.

- New `cursorPagination` flag plumbed through `PaginationIterable`/`PaginationIterator` (and the matching `.j2` templates).
- Generator template `Api.j2` passes `pagination.cursorParam` into the constructor.
- Regenerated 31 API classes (50 `new PaginationIterable(...)` call sites).

The supporting cassettes (extra trailing `{"data":[]}` response) were already added in #3559 when the Go/Ruby clients shipped this change.

## Test plan

- [x] `mvn clean compile` succeeds
- [x] All `@with-pagination` Cucumber scenarios pass (37/37)

🤖 Generated with [Claude Code](https://claude.com/claude-code)