### PR TITLE
Do not return UnparsedObject when matching nested oneOf schema

### DIFF
--- a/.generator/src/generator/templates/modelOneOf.j2
+++ b/.generator/src/generator/templates/modelOneOf.j2
@@ -83,6 +83,9 @@ public class {{ name }} extends AbstractOpenApiSchema {
             {%- set parameterizedDataType = get_type(oneOf) %}
             {%- set unParameterizedDataType = parameterizedDataType|un_parameterize_type %}
             {%- set isParameterized = parameterizedDataType|is_parameterized_type %}
+            {%- set isModelMember = not oneOf|is_primitive and not unParameterizedDataType|lower|is_java_base_type and "enum" not in oneOf %}
+            {%- set isComposedMember = "oneOf" in oneOf or "anyOf" in oneOf %}
+            {%- set isModelListMember = "items" in oneOf and oneOf.get("items")|is_model and not oneOf|is_primitive %}
             // deserialize {{ parameterizedDataType }}
             try {
                 boolean attemptParsing = true;
@@ -108,12 +111,20 @@ public class {{ name }} extends AbstractOpenApiSchema {
                     // TODO: there is no validation against JSON schema constraints
                     // (min, max, enum, pattern...), this does not perform a strict JSON
                     // validation, which means the 'match' count may be higher than it should be.
-                    {%- if not oneOf|is_primitive and not unParameterizedDataType|lower|is_java_base_type and "enum" not in oneOf %}
-                    if (!(({{ unParameterizedDataType }})tmp).unparsed) {
+                    {%- if isModelMember %}
+                    if (!(({{ unParameterizedDataType }}) tmp).unparsed
+                    {%- if isComposedMember %}
+		            {#- unmatched oneOf doesn't propagate to "tmp.unparsed": we aim
+			        for today's client to be forward-compatible with future oneOf
+				branches. But a oneOf branch that it itself a oneOf? We _must_
+				respect the nested oneOf's `unparsed` or the oneOf branch will
+				always match. #}
+                            && !((({{ unParameterizedDataType }}) tmp).getActualInstance() instanceof UnparsedObject)
+                    {%- endif %}) {
                         deserialized = tmp;
                         match++;
                     }
-                    {%- elif "items" in oneOf and oneOf.get("items")|is_model and not oneOf|is_primitive %}
+                    {%- elif isModelListMember %}
                     {%- set itemsDataType = get_type(oneOf.get("items")) %}
                     // keep the matched list, but propagate 'unparsed' from any invalid item
                     boolean itemsUnparsed = false;

--- a/src/main/java/com/datadog/api/client/v2/model/CIAppCreatePipelineEventRequestAttributesResource.java
+++ b/src/main/java/com/datadog/api/client/v2/model/CIAppCreatePipelineEventRequestAttributesResource.java
@@ -124,7 +124,9 @@ public class CIAppCreatePipelineEventRequestAttributesResource extends AbstractO
           // TODO: there is no validation against JSON schema constraints
           // (min, max, enum, pattern...), this does not perform a strict JSON
           // validation, which means the 'match' count may be higher than it should be.
-          if (!((CIAppPipelineEventPipeline) tmp).unparsed) {
+          if (!((CIAppPipelineEventPipeline) tmp).unparsed
+              && !(((CIAppPipelineEventPipeline) tmp).getActualInstance()
+                  instanceof UnparsedObject)) {
             deserialized = tmp;
             match++;
           }
@@ -214,7 +216,8 @@ public class CIAppCreatePipelineEventRequestAttributesResource extends AbstractO
           // TODO: there is no validation against JSON schema constraints
           // (min, max, enum, pattern...), this does not perform a strict JSON
           // validation, which means the 'match' count may be higher than it should be.
-          if (!((CIAppPipelineEventJob) tmp).unparsed) {
+          if (!((CIAppPipelineEventJob) tmp).unparsed
+              && !(((CIAppPipelineEventJob) tmp).getActualInstance() instanceof UnparsedObject)) {
             deserialized = tmp;
             match++;
           }

--- a/src/main/java/com/datadog/api/client/v2/model/UpsertCatalogEntityRequest.java
+++ b/src/main/java/com/datadog/api/client/v2/model/UpsertCatalogEntityRequest.java
@@ -111,7 +111,8 @@ public class UpsertCatalogEntityRequest extends AbstractOpenApiSchema {
           // TODO: there is no validation against JSON schema constraints
           // (min, max, enum, pattern...), this does not perform a strict JSON
           // validation, which means the 'match' count may be higher than it should be.
-          if (!((EntityV3) tmp).unparsed) {
+          if (!((EntityV3) tmp).unparsed
+              && !(((EntityV3) tmp).getActualInstance() instanceof UnparsedObject)) {
             deserialized = tmp;
             match++;
           }

--- a/src/test/java/com/datadog/api/client/v2/api/CIAppPipelineEventJobTest.java
+++ b/src/test/java/com/datadog/api/client/v2/api/CIAppPipelineEventJobTest.java
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+package com.datadog.api.client.v2.api;
+
+import static com.datadog.api.World.fromJSON;
+import static org.junit.Assert.assertEquals;
+
+import com.datadog.api.client.v2.model.CIAppCreatePipelineEventRequestAttributesResource;
+import com.datadog.api.client.v2.model.CIAppPipelineEventFinishedJob;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CIAppPipelineEventJobTest extends V2APITest {
+
+  private static ObjectMapper objectMapper;
+
+  @Override
+  public String getTracingEndpoint() {
+    return "ci-app";
+  }
+
+  @BeforeClass
+  public static void initApi() {
+    objectMapper = generalApiUnitTestClient.getJSON().getMapper();
+  }
+
+  @Test
+  public void testDeserializeNestedOneOfJob() throws JsonProcessingException {
+    String body =
+        "{\"end\":\"2023-01-01T12:00:01+00:00\",\"id\":\"job-id\",\"level\":\"job\",\"name\":\"job-name\",\"pipeline_name\":\"my-pipeline\",\"pipeline_unique_id\":\"pipeline-unique-id\",\"start\":\"2023-01-01T12:00:00+00:00\",\"status\":\"success\",\"url\":\"https://example.com/job\"}";
+    CIAppCreatePipelineEventRequestAttributesResource res =
+        fromJSON(objectMapper, CIAppCreatePipelineEventRequestAttributesResource.class, body);
+
+    CIAppPipelineEventFinishedJob finishedJob =
+        res.getCIAppPipelineEventJob().getCIAppPipelineEventFinishedJob();
+    assertEquals("job-id", finishedJob.getId());
+  }
+}


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **
* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

Removes some `UnparsedObject`s that come from `oneOf`.

I found that #4062 was failing CI because of an underlying reason: if a `oneOf` contains a "nested" `oneOf`, the nested one is always marked as "parsed" even if it isn't. The outcome: any `oneOf` that itself contained a (direct) unparsed `oneOf` branch was being parsed as `UnparsedObject`.

(This seems backwards: why does an inner "faux-parsed" `oneOf` branch mean the _outer_ `oneOf` fails? Isn't "parsed" going to give false _positives_, not false _negatives_? No: a `oneOf` must match exactly one branch; if we accidentally mark the faux-parsed `oneOf` branch as parsed, then _two_ branches are marked as parsed and the outer oneOf is therefore unmatched.)

Why isn't a `oneOf` marked as `unparsed` when no branch matches? Because we try to be forward-compatible with _future_ objects (see #944). But it turns out we've been shipping `UnparsedObject` for years. I've unit-tested a 2023 class (introduced in #1843) as part of the fix.

### Additional Notes

It's hard to choose where to draw the line here -- which part of a request should be marked `UnparsedObject` and which part should succeed? I didn't try to formalize it; I just focused on ensuring that some _valid_ objects get marked as parsed where they weren't before.

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.
- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR that includes tests.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
