### PR TITLE
Fix generated oneOf examples for array aliases

### DIFF
--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -530,6 +530,11 @@ def format_data_with_schema_list(
             except (KeyError, ValueError):
                 continue
 
+            if matched_sub_schema.get("x-generate-alias-as-model"):
+                alias_name = schema_name(matched_sub_schema)
+                one_of_imports.add(alias_name)
+                value = f"new {alias_name}({value})"
+
             if name:
                 one_of_imports.add(f"{name}")
                 # Detect if we need to use factory method due to type erasure collision

--- a/.generator/src/generator/templates/modelSimple.j2
+++ b/.generator/src/generator/templates/modelSimple.j2
@@ -16,6 +16,14 @@
 public class {{ name }} {%- if model.get("x-generate-alias-as-model") %} extends {% if "items" in model %}ArrayList<{{ get_type(model["items"]) }}>{% else %}{{ get_type(model) }}{% endif %}{% endif %} {
   @JsonIgnore
   public boolean unparsed = false;
+  {%- if model.get("x-generate-alias-as-model") and "items" in model %}
+
+  public {{ name }}() {}
+
+  public {{ name }}(List<{{ get_type(model["items"]) }}> items) {
+    super(items);
+  }
+  {%- endif %}
   {%- for attr, schema in model.get("properties", {}).items() %}
   {%- set attributeName = attr|attribute_name %}
   {%- set variableName = attr|variable_name %}
@@ -46,7 +54,9 @@ public class {{ name }} {%- if model.get("x-generate-alias-as-model") %} extends
 
   {%- set requiredAttr = model|get_required_attributes %}
   {%- if requiredAttr %}
+  {%- if not (model.get("x-generate-alias-as-model") and "items" in model) %}
   public {{ name }}() {}
+  {%- endif %}
 
   @JsonCreator
   public {{ name }}(

--- a/.generator/tests/test_formatter.py
+++ b/.generator/tests/test_formatter.py
@@ -1,0 +1,117 @@
+# coding=utf-8
+"""Unit tests for the formatter module."""
+
+import yaml
+from click.testing import CliRunner
+
+from generator.cli import cli
+from generator.formatter import format_data_with_schema
+
+
+class SchemaWithRef(dict):
+    """A schema dict that carries a $ref, as the generator produces after resolving references."""
+
+    def __init__(self, *args, ref=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if ref:
+            self.__reference__ = {"$ref": ref}
+
+
+def test_named_array_alias_in_oneof_uses_generated_wrapper():
+    message_schema = SchemaWithRef(
+        {
+            "type": "object",
+            "properties": {
+                "role": {"type": "string"},
+                "content": {"type": "string"},
+            },
+            "required": ["role", "content"],
+        },
+        ref="#/components/schemas/LLMObsPromptChatMessage",
+    )
+    chat_schema = SchemaWithRef(
+        {
+            "type": "array",
+            "items": message_schema,
+            "x-generate-alias-as-model": True,
+        },
+        ref="#/components/schemas/LLMObsPromptChatTemplate",
+    )
+    template_schema = SchemaWithRef(
+        {"oneOf": [{"type": "string"}, chat_schema]},
+        ref="#/components/schemas/LLMObsPromptTemplate",
+    )
+
+    _, result, imports = format_data_with_schema(
+        [
+            {"role": "system", "content": "You help {{company_name}} customers."},
+            {"role": "user", "content": "Answer {{question}}"},
+        ],
+        template_schema,
+    )
+
+    assert (
+        "new LLMObsPromptTemplate(new LLMObsPromptChatTemplate("
+        "Arrays.asList(" in result
+    )
+    assert "new LLMObsPromptTemplate(Arrays.asList(" not in result
+    assert "LLMObsPromptChatTemplate" in imports
+
+
+def test_named_array_alias_model_accepts_formatted_list(tmp_path):
+    spec_dir = tmp_path / "v2"
+    spec_dir.mkdir()
+    spec_path = spec_dir / "openapi.yaml"
+    spec_path.write_text(
+        yaml.safe_dump(
+            {
+                "openapi": "3.0.0",
+                "info": {"title": "test", "version": "1"},
+                "servers": [{"url": "https://api.example.com", "variables": {}}],
+                "paths": {
+                    "/test": {
+                        "post": {
+                            "operationId": "TestArrayAlias",
+                            "tags": ["Test"],
+                            "requestBody": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/LLMObsPromptChatTemplate"
+                                        }
+                                    }
+                                }
+                            },
+                            "responses": {"200": {"description": "OK"}},
+                        }
+                    }
+                },
+                "components": {
+                    "securitySchemes": {},
+                    "schemas": {
+                        "LLMObsPromptChatMessage": {
+                            "type": "object",
+                            "properties": {
+                                "role": {"type": "string"},
+                                "content": {"type": "string"},
+                            },
+                        },
+                        "LLMObsPromptChatTemplate": {
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/LLMObsPromptChatMessage"},
+                            "x-generate-alias-as-model": True,
+                        },
+                    }
+                },
+            }
+        )
+    )
+    output = tmp_path / "generated"
+
+    result = CliRunner().invoke(cli, [str(spec_path), "--output", str(output)])
+
+    assert result.exit_code == 0
+    model = (output / "v2/model/LLMObsPromptChatTemplate.java").read_text()
+    assert "public LLMObsPromptChatTemplate() {}" in model
+    assert "public LLMObsPromptChatTemplate(List<LLMObsPromptChatMessage> items)" in model
+    assert "super(items);" in model


### PR DESCRIPTION
## What changed

When a `oneOf` selects an array schema generated as a named model, wrap the formatted list in that model before passing it to the outer union model. Generated array-alias models now expose the minimal constructors needed for that expression: a no-argument constructor and a constructor accepting the underlying `List`.

The formatter change only applies to array branches carrying `x-generate-alias-as-model`.

## Why

This was discovered while adding realistic chat-template examples to [DataDog/datadog-api-spec#6113](https://github.com/DataDog/datadog-api-spec/pull/6113). The prompt template is a `oneOf` between a string and the named `LLMObsPromptChatTemplate` array alias.

The generator produced code equivalent to:

```java
new LLMObsPromptTemplate(Arrays.asList(new LLMObsPromptChatMessage(...)))
```

but `LLMObsPromptTemplate` accepts either a `String` or an `LLMObsPromptChatTemplate`, not a raw `List<LLMObsPromptChatMessage>`. This caused the generated chat example to fail compilation and forced the spec example to use the text branch.

The generated expression is now equivalent to:

```java
new LLMObsPromptTemplate(
    new LLMObsPromptChatTemplate(Arrays.asList(new LLMObsPromptChatMessage(...))))
```

## Validation

Added focused regression coverage that:

- verifies the string-or-chat-array union produces the named wrapper and not the previous raw-list expression;
- runs the generator for an array alias and verifies the generated model accepts the formatted list.