### PR TITLE
[AGV-1597] Add is_iac support to send X-Datadog-Managed-By header

### DIFF
--- a/.generator/src/generator/templates/ApiClient.j2
+++ b/.generator/src/generator/templates/ApiClient.j2
@@ -129,6 +129,7 @@ public class ApiClient {
   {%- set default_server = openapi.servers[0]|format_server %}
   protected String basePath = "{{ default_server.geturl() }}";
   protected String userAgent;
+  private boolean isIaC = false;
   private DateTimeFormatter offsetDateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
   protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(
@@ -672,6 +673,31 @@ public class ApiClient {
   public ApiClient addDefaultHeader(String key, String value) {
     defaultHeaderMap.put(key, value);
     return this;
+  }
+
+  /**
+   * Set whether this API client is managed by Infrastructure as Code (IaC) tooling. When enabled,
+   * the {@code X-Datadog-Managed-By: iac} header is sent on every request made through this client
+   * (by adding to the default header map).
+   * @param isIaC Whether calls made with this client originate from IaC tooling
+   * @return API client
+   */
+  public ApiClient setIsIaC(boolean isIaC) {
+    this.isIaC = isIaC;
+    if (isIaC) {
+      addDefaultHeader("X-Datadog-Managed-By", "iac");
+    } else {
+      defaultHeaderMap.remove("X-Datadog-Managed-By");
+    }
+    return this;
+  }
+
+  /**
+   * Get whether this API client is managed by Infrastructure as Code (IaC) tooling.
+   * @return Whether this client is managed by IaC tooling
+   */
+  public boolean getIsIaC() {
+    return isIaC;
   }
 
   /**

--- a/src/main/java/com/datadog/api/client/ApiClient.java
+++ b/src/main/java/com/datadog/api/client/ApiClient.java
@@ -77,6 +77,7 @@ public class ApiClient {
   protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
   protected String basePath = "https://api.datadoghq.com";
   protected String userAgent;
+  private boolean isIaC = false;
   private DateTimeFormatter offsetDateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
   protected List<ServerConfiguration> servers =
@@ -1920,6 +1921,33 @@ public class ApiClient {
   public ApiClient addDefaultHeader(String key, String value) {
     defaultHeaderMap.put(key, value);
     return this;
+  }
+
+  /**
+   * Set whether this API client is managed by Infrastructure as Code (IaC) tooling. When enabled,
+   * the {@code X-Datadog-Managed-By: iac} header is sent on every request made through this client
+   * (by adding to the default header map).
+   *
+   * @param isIaC Whether calls made with this client originate from IaC tooling
+   * @return API client
+   */
+  public ApiClient setIsIaC(boolean isIaC) {
+    this.isIaC = isIaC;
+    if (isIaC) {
+      addDefaultHeader("X-Datadog-Managed-By", "iac");
+    } else {
+      defaultHeaderMap.remove("X-Datadog-Managed-By");
+    }
+    return this;
+  }
+
+  /**
+   * Get whether this API client is managed by Infrastructure as Code (IaC) tooling.
+   *
+   * @return Whether this client is managed by IaC tooling
+   */
+  public boolean getIsIaC() {
+    return isIaC;
   }
 
   /**

--- a/src/test/java/com/datadog/api/client/ApiClientTest.java
+++ b/src/test/java/com/datadog/api/client/ApiClientTest.java
@@ -1,0 +1,54 @@
+package com.datadog.api.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ApiClientTest {
+
+  @Test
+  public void testIsIaCDisabledByDefault() {
+    ApiClient client = new ApiClient();
+    assertFalse(client.getIsIaC());
+    assertFalse(client.defaultHeaderMap.containsKey("X-Datadog-Managed-By"));
+  }
+
+  @Test
+  public void testSetIsIaCTrueAddsManagedByHeaderToDefaultHeaders() {
+    ApiClient client = new ApiClient();
+
+    ApiClient returned = client.setIsIaC(true);
+
+    assertSame(client, returned);
+    assertTrue(client.getIsIaC());
+    // defaultHeaderMap is merged into the headers of every request made through this client,
+    // see ApiClient#createBuilder.
+    assertEquals("iac", client.defaultHeaderMap.get("X-Datadog-Managed-By"));
+  }
+
+  @Test
+  public void testSetIsIaCFalseRemovesManagedByHeader() {
+    ApiClient client = new ApiClient();
+    client.setIsIaC(true);
+
+    client.setIsIaC(false);
+
+    assertFalse(client.getIsIaC());
+    assertFalse(client.defaultHeaderMap.containsKey("X-Datadog-Managed-By"));
+  }
+
+  @Test
+  public void testSetIsIaCIsPerClientInstance() {
+    ApiClient iacClient = new ApiClient();
+    ApiClient defaultClient = new ApiClient();
+
+    iacClient.setIsIaC(true);
+
+    assertTrue(iacClient.getIsIaC());
+    assertFalse(defaultClient.getIsIaC());
+    assertFalse(defaultClient.defaultHeaderMap.containsKey("X-Datadog-Managed-By"));
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `ApiClient.setIsIaC(boolean)` / `getIsIaC()`, which when enabled sends the `X-Datadog-Managed-By: iac` header on all requests.
- Lets Datadog distinguish infrastructure-as-code API traffic from other client usage.
- Configured at client-creation time via `ApiClient`; existing constructors are unaffected.

## Test plan
- [x] New `ApiClientTest` covering header-off-by-default and header-set-when-enabled behavior
- [x] Full test suite passes

___All of the API generation is moving to a new repo. This PR may never be merged, but changes are present in [openapi-transformer#389](https://github.com/DataDog/openapi-transformer/pull/389)___

🤖 Generated with [Claude Code](https://claude.com/claude-code)